### PR TITLE
fbfw-64 create absolute position container

### DIFF
--- a/beta-src/src/assets/css/App.css
+++ b/beta-src/src/assets/css/App.css
@@ -1,0 +1,3 @@
+.App {
+  position: "relative";
+}

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
-import { useCallback } from "react";
+import { useMemo } from "react";
 
 export enum Position {
   BOTTOM_LEFT = "bottom-left",
@@ -31,7 +31,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
   children,
   position,
 }): React.ReactElement {
-  const getPositionValues = useCallback(() => {
+  const getPositionValues = useMemo(() => {
     switch (position) {
       case Position.BOTTOM_LEFT:
         return { bottom: responsiveDistance, left: responsiveDistance };
@@ -50,7 +50,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
       sx={{
         position: "absolute",
         zIndex: Z_INDEX,
-        ...getPositionValues(),
+        ...getPositionValues,
       }}
     >
       {children}

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -1,13 +1,7 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import { useMemo } from "react";
-
-export enum Position {
-  BOTTOM_LEFT = "bottom-left",
-  BOTTOM_RIGHT = "bottom-right",
-  TOP_LEFT = "top-left",
-  TOP_RIGHT = "top-right",
-}
+import Position from "../../enums/Position";
 
 interface WDPositionContainerProps {
   children: React.ReactNode;

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -16,6 +16,7 @@ interface WDPositionContainerProps {
 
 const MOBILE_DISTANCE = 16;
 const TABLET_UP_DISTANCE = 24;
+const Z_INDEX = 2;
 
 const responsiveDistance = {
   mobile: MOBILE_DISTANCE,
@@ -48,7 +49,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
     <Box
       sx={{
         position: "absolute",
-        zIndex: 2,
+        zIndex: Z_INDEX,
         ...getPositionValues(),
       }}
     >

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import { useCallback } from "react";
+
+export enum Position {
+  BOTTOM_LEFT = "bottom-left",
+  BOTTOM_RIGHT = "bottom-right",
+  TOP_LEFT = "top-left",
+  TOP_RIGHT = "top-right",
+}
+
+interface WDPositionContainerProps {
+  children: React.ReactNode;
+  position?: Position;
+}
+
+const MOBILE_DISTANCE = 16;
+const TABLET_UP_DISTANCE = 24;
+
+const responsiveDistance = {
+  mobile: MOBILE_DISTANCE,
+  tablet: TABLET_UP_DISTANCE,
+  desktop: TABLET_UP_DISTANCE,
+} as const;
+
+/**
+ * This component is used to position a box and its children absolute
+ */
+const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
+  children,
+  position,
+}): React.ReactElement {
+  const getPositionValues = useCallback(() => {
+    switch (position) {
+      case Position.BOTTOM_LEFT:
+        return { bottom: responsiveDistance, left: responsiveDistance };
+      case Position.BOTTOM_RIGHT:
+        return { bottom: responsiveDistance, right: responsiveDistance };
+      case Position.TOP_RIGHT:
+        return { right: responsiveDistance, top: responsiveDistance };
+      case Position.TOP_LEFT:
+      default:
+        return { left: responsiveDistance, top: responsiveDistance };
+    }
+  }, [position]);
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        zIndex: 2,
+        ...getPositionValues(),
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+WDPositionContainer.defaultProps = {
+  position: Position.TOP_LEFT,
+};
+
+export default WDPositionContainer;

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -31,7 +31,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
   children,
   position,
 }): React.ReactElement {
-  const getPositionValues = useMemo(() => {
+  const placement = useMemo(() => {
     switch (position) {
       case Position.BOTTOM_LEFT:
         return { bottom: responsiveDistance, left: responsiveDistance };
@@ -50,7 +50,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
       sx={{
         position: "absolute",
         zIndex: Z_INDEX,
-        ...getPositionValues,
+        ...placement,
       }}
     >
       {children}

--- a/beta-src/src/enums/Position.ts
+++ b/beta-src/src/enums/Position.ts
@@ -1,0 +1,8 @@
+export enum Position {
+  BOTTOM_LEFT = "bottom-left",
+  BOTTOM_RIGHT = "bottom-right",
+  TOP_LEFT = "top-left",
+  TOP_RIGHT = "top-right",
+}
+
+export default Position;


### PR DESCRIPTION
this pr creates a box component that absolute positions content in the follow places inside a layout parent:

bottom-left
bottom-right
top-left (default)
top-right

currently the mocks require only these positions and in each case, the values for top, left, bottom, right are hardcoded to be 16px for mobile and 24px for tablet and desktop.

the values are for mvp and are subject to change.

testing:
===
with this branch, load the web app. ensure the boxes are positioned properly in the expected corners for each value using markup similar to this:

```
import WDPositionContainer, {Position} from ...

...

<WDPositionContainer position={Position.TOP_RIGHT}>
  <Grid
    container
    direction="column"
    justifyContent="center"
    alignItems="center"
  >
    <Grid item>
      <IconButton aria-label="Example" onClick={() => alert("click")}>
        <SvgIcon fontSize="large">
          <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
        </SvgIcon>
      </IconButton>
    </Grid>
    <Grid item>
      <IconButton aria-label="Example" onClick={() => alert("click")}>
        <ControlCameraIcon fontSize="large" />
      </IconButton>
    </Grid>
  </Grid>
</WDPositionContainer>
```

NOTE: import Position from WDPositionContainer to set the position prop, unless you want top-left, the default value

results:
===

mobile:
![Screen Shot 2022-02-18 at 9 25 58 AM](https://user-images.githubusercontent.com/37419695/154733606-3d3795fb-a110-45e5-a728-cb3f26ac0686.png)

---

tablet:
![Screen Shot 2022-02-18 at 9 26 12 AM](https://user-images.githubusercontent.com/37419695/154733583-795d5400-bf26-4399-b341-60b60603b90d.png)

---

desktop:
![Screen Shot 2022-02-18 at 9 26 24 AM](https://user-images.githubusercontent.com/37419695/154733563-ba6a9c35-321d-4881-92c9-5889d13660ad.png)

---

ensure that clicking and dragging the map still works as expected and the boxes to not interfere:

https://user-images.githubusercontent.com/37419695/154733475-8db4dd5e-1d5c-4a07-a5b6-30a11a168eab.mov

