### PR TITLE
Setup game data API route. GetGameData will now return the context va…

### DIFF
--- a/api.php
+++ b/api.php
@@ -193,7 +193,7 @@ abstract class ApiEntry {
 			'success' => $success,
 			'referenceCode' =>$referenceCode,
 			'data' => $data,
-		]);
+		], JSON_NUMERIC_CHECK);
 	}
 
 	/**
@@ -411,12 +411,28 @@ class GetGameOverview extends ApiEntry {
 	public function run($userID, $permissionIsExplicit) {
 		$args = $this->getArgs();
 		$gameID = $args['gameID'];
-		if ($gameID === null || !ctype_digit($gameID))
-			throw new RequestException('Invalid game ID: '.$gameID);
-		if (!empty(Config::$apiConfig['restrictToGameIDs']) && !in_array($gameID, Config::$apiConfig['restrictToGameIDs']))
-		    throw new ClientForbiddenException('Game ID is not in list of gameIDs where API usage is permitted.');
+		if ($gameID === null || !ctype_digit($gameID)){
+			throw new RequestException(
+				$this->JSONResponse(
+					'Invalid game ID.', 
+					'GGO-err-001', 
+					false,
+					['gameID' => $gameID]
+				)
+			);
+		}
+		if (!empty(Config::$apiConfig['restrictToGameIDs']) && !in_array($gameID, Config::$apiConfig['restrictToGameIDs'])){
+			throw new ClientForbiddenException(
+				$this->JSONResponse(
+					'Game ID is not in list of gameIDs where API usage is permitted.', 
+					'GGO-err-002', 
+					false, 
+					['gameID' => $gameID]
+				)
+			);
+		}   
 		$game = $this->getAssociatedGame();
-		$json = [
+		$payload = [
 			'anon' => $game->anon,
 			'drawType' => $game->drawType,
 			'excusedMissedTurns' => $game->excusedMissedTurns,
@@ -437,7 +453,7 @@ class GetGameOverview extends ApiEntry {
 			'variant' => $game->Variant,
 			'variantID' => $game->variantID,
 		];
-		return json_encode( $json, JSON_NUMERIC_CHECK );
+		return $this->JSONResponse('Successfully retrieved game overview.', 'GGO-s-001', true, $payload);
 	}
 }
 

--- a/api.php
+++ b/api.php
@@ -187,7 +187,7 @@ abstract class ApiEntry {
 		$this->requirements = $requirements;
 	}
 
-	protected function JSONResponse(string $msg, string $referenceCode, bool $success, array $data){
+	protected function JSONResponse(string $msg, string $referenceCode, bool $success, array $data = []){
 		return json_encode([
 			'msg' => $msg,
 			'success' => $success,
@@ -538,7 +538,7 @@ class GetGameData extends ApiEntry {
 			$payload['currentOrders'] = $this->getCurrentOrders();
 		}
 
-		return json_encode($payload);
+		return $this->JSONResponse('Successfully retrieved data.', 'GGD-s-001', true, $payload);
 	}
 }
 

--- a/board/orders/orderinterface.php
+++ b/board/orders/orderinterface.php
@@ -277,12 +277,21 @@ class OrderInterface
 		return array('context'=>$context, 'json'=>$json, 'key'=>md5(Config::$jsonSecret.$json).sha1(Config::$jsonSecret.$json));
 	}
 
-	protected function jsContextVars() {
+	public function getContextVars(){
 		$context = self::getContext($this);
+		return [
+			'context' => $context['json'],
+			'contextKey' => $context['key'],
+			'ordersData' => $this->Orders
+		];
+	}
+
+	protected function jsContextVars() {
+		$contextVars = $this->getContextVars();
 		libHTML::$footerScript[] = '
-	context='.$context['json'].';
-	contextKey="'.$context['key'].'";
-	ordersData = '.json_encode($this->Orders).';
+	context='.$contextVars['context'].';
+	contextKey="'.$contextVars['contextKey'].'";
+	ordersData = '.json_encode($contextVars['ordersData']).';
 	';
 	}
 


### PR DESCRIPTION
Added an API route: `GetGameData`

This API route returns `contextVars` and `currentOrders` when successful. In order to retrieve the `contextVars` and `currentOrders`, the countryID is required. Not providing a country ID doesn't fail this route since the unit, territory status, and territories data will be available without providing a country ID. 

### contextVars
```
{
    "msg": "Successfully retrieved data.",
    "success": true,
    "referenceCode": "GGD-s-001",
    "data": {
        "contextVars": {
            "context": "{\"gameID\":14,\"variantID\":1,\"userID\":5,\"memberID\":1787,\"turn\":3,\"phase\":\"Builds\",\"countryID\":\"2\",\"tokenExpireTime\":null,\"maxOrderID\":\"2335\",\"orderStatus\":\"Saved,Completed\"}",
            "contextKey": "cd1737caf19b259ad308ded186bf2f7854c656dfa93859cea9798270bda2e9134f72dd97"
        },
        "currentOrders": [
            {
                "error": null,
                "status": "Loading",
                "id": 2335,
                "type": "Build Army",
                "unitID": null,
                "toTerrID": 47,
                "fromTerrID": null,
                "viaConvoy": null
            }
        ]
    }
}
```

### currentOrders
```
[{"error": null,"status": "Loading","id": "2335","type": "Build Army","unitID": null,"toTerrID": "47","fromTerrID": null,"viaConvoy": null}]
```
Reference: https://codazen.atlassian.net/wiki/spaces/FWD/pages/2532442115/Unit+Order+Generation

You can see the order above is for building an army in a specific territory. 
**This is what the order looks like in legacy:**
<img width="780" alt="Screen Shot 2022-03-21 at 3 00 42 PM" src="https://user-images.githubusercontent.com/93741108/159363089-0b60d9e6-ef8d-4f99-9019-7d842de720b3.png">

Current orders are only accessible if they've been saved. 

### Testing
Call the API route for a specific route when logged in.

Route: `/api.php?route=game/data&gameID=14&countryID=2`

All responses will come through as `Content-Type` of `text/plain`: 
Any plain text responses such as "Access to this page denied for your account type." and "Game ID not provided." will be errors. JSON responses can be errors or successful responses. The JSON responses will contain a `success` property which will be true or false. 

**Properties:**

1. `msg`: a text message (can be an empty string)
2. `success`: boolean
3. `referenceCode`: used to quickly find source within codebase if needed. For example: reference code GGD-err-002. 
4. `data`: the payload or other relevant data

Unfortunately, it is not possible to refactor these response types at this time due to how coupled the logic is with other APIs and other aspects of the code. Even JSON responses will come through as "text", though these can be parsed client side. 

Only the game/overview and game/data routes use the `JSONResponse()` method. 

### Testing Link
There is none, you need to create a local game and call the API route explained above. 