### PR TITLE
 fbfw-70-full-modal-view-info-panel completed

### DIFF
--- a/beta-src/src/components/ui/WDFullModal.tsx
+++ b/beta-src/src/components/ui/WDFullModal.tsx
@@ -1,0 +1,134 @@
+import * as React from "react";
+import { useState } from "react";
+import { Box, Stack, Button } from "@mui/material";
+import WDInfoDisplay from "./WDInfoDisplay";
+import GameMode from "../../enums/GameMode";
+import Season from "../../enums/Season";
+import Ranking from "../../enums/Ranking";
+import IntegerRange from "../../types/IntegerRange";
+import GameType from "../../enums/GameType";
+import { CountryTableData } from "../../interfaces";
+import Device from "../../enums/Device";
+import WDInfoPanel from "./WDInfoPanel";
+import WDPress from "./WDPress";
+import ModalViews from "../../enums/ModalViews";
+
+interface WDFullModalProps {
+  children: React.ReactNode;
+  countries: CountryTableData[];
+  device: Device;
+  gameMode: GameMode;
+  gameType: GameType;
+  maxDelays: IntegerRange<0, 5>;
+  potNumber: IntegerRange<35, 665>;
+  rank: Ranking;
+  season: Season;
+  title: string;
+  userCountry: CountryTableData;
+  year: number;
+}
+
+const textButtonStyle = {
+  borderRadius: 0,
+  fontWeight: 400,
+  minWidth: 0,
+  p: "0 0 5px 0",
+  "&:hover": {
+    background: "transparent",
+  },
+};
+
+const textButtonSelected = {
+  borderRadius: 0,
+  borderBottom: "solid black 2px",
+  fontWeight: 600,
+  minWidth: 0,
+  p: "0 0 5px 0",
+  "&:hover": {
+    background: "transparent",
+  },
+};
+
+const WDFullModal: React.FC<WDFullModalProps> = function ({
+  children,
+  countries,
+  device,
+  gameMode,
+  gameType,
+  maxDelays,
+  potNumber,
+  rank,
+  season,
+  title,
+  userCountry,
+  year,
+}): React.ReactElement {
+  const [view, setView] = useState("info");
+  const mobileLandscapeLayout =
+    device === Device.MOBILE_LANDSCAPE || device === Device.MOBILE_LG_LANDSCAPE;
+
+  const padding = mobileLandscapeLayout ? "0 6px" : "0 16px";
+
+  const renderView = () => {
+    if (view === "info") {
+      return (
+        <Box>
+          <Box
+            sx={{
+              m: "20px 0 10px 0",
+              p: padding,
+            }}
+          >
+            <WDInfoDisplay
+              device={device}
+              gameMode={gameMode}
+              gameType={gameType}
+              potNumber={potNumber}
+              rank={rank}
+              season={season}
+              title={title}
+              year={year}
+            />
+          </Box>
+          <WDInfoPanel
+            countries={countries}
+            device={device}
+            maxDelays={maxDelays}
+            userCountry={userCountry}
+          />
+        </Box>
+      );
+    }
+    if (view === "press") {
+      return <WDPress device={device}>{children}</WDPress>;
+    }
+    return null;
+  };
+
+  return (
+    <Box>
+      <Stack
+        alignItems="center"
+        direction="row"
+        spacing={2}
+        sx={{ p: padding }}
+      >
+        <Button
+          onClick={() => setView("press")}
+          sx={view === "press" ? textButtonSelected : textButtonStyle}
+        >
+          {ModalViews.PRESS}
+        </Button>
+        <Button
+          onClick={() => setView("info")}
+          sx={view === "info" ? textButtonSelected : textButtonStyle}
+        >
+          {ModalViews.INFO}
+        </Button>
+      </Stack>
+      {renderView()}
+    </Box>
+  );
+};
+
+export default WDFullModal;

--- a/beta-src/src/components/ui/WDInfoDisplay.tsx
+++ b/beta-src/src/components/ui/WDInfoDisplay.tsx
@@ -13,12 +13,14 @@ import Ranking from "../../enums/Ranking";
 import IntegerRange from "../../types/IntegerRange";
 import GameType from "../../enums/GameType";
 import WDLineClamp from "./WDLineClamp";
+import Device from "../../enums/Device";
 
 /**
  * game setting datas which would be passed to the component by parent component/ context/redux store
  */
 
 interface WDInfoDisplayProps {
+  device: Device;
   gameMode: GameMode;
   gameType: GameType;
   potNumber: IntegerRange<35, 665>;
@@ -35,6 +37,7 @@ const tableCellStyles = {
 };
 
 const WDInfoDisplay: React.FC<WDInfoDisplayProps> = function ({
+  device,
   gameMode,
   gameType,
   potNumber,
@@ -43,13 +46,16 @@ const WDInfoDisplay: React.FC<WDInfoDisplayProps> = function ({
   title,
   year,
 }) {
+  const mobileLandscapeLayout =
+    device === Device.MOBILE_LANDSCAPE || device === Device.MOBILE_LG_LANDSCAPE;
+  const maximumWeight = mobileLandscapeLayout ? 250 : 345;
   return (
     <TableContainer>
       <Table
         aria-label="A table of game information"
         size="small"
         sx={{
-          maxWidth: 250,
+          maxWidth: maximumWeight,
         }}
       >
         <TableHead>

--- a/beta-src/src/components/ui/WDInfoPanel.tsx
+++ b/beta-src/src/components/ui/WDInfoPanel.tsx
@@ -23,26 +23,40 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
   const [voteState, setVoteState] = React.useState(userCountry.votes);
 
   const toggleVote = (voteName: Vote) => {
+    const voteKey = Vote[voteName];
     const newVoteState = {
       ...voteState,
-      [voteName]: !voteState[voteName],
+      [voteKey]: !voteState[voteKey],
     };
 
     setVoteState(newVoteState);
   };
 
+  const mobileLandscapeLayout =
+    device === Device.MOBILE_LANDSCAPE || device === Device.MOBILE_LG_LANDSCAPE;
+
+  const padding = mobileLandscapeLayout ? "0 6px" : "0 16px";
+
   return (
     <Box>
-      <WDVoteButtons voteState={voteState} toggleVote={toggleVote} />
-      <WDCountryTable
-        maxDelays={maxDelays}
-        /**
-         * always show current user at the top
-         *
-         */
-        countries={[{ ...userCountry, votes: voteState }, ...countries]}
-        device={device}
-      />
+      <Box sx={{ p: padding }}>
+        <WDVoteButtons voteState={voteState} toggleVote={toggleVote} />
+      </Box>
+      <Box
+        sx={{
+          m: "20px 5px 10px 0",
+        }}
+      >
+        <WDCountryTable
+          maxDelays={maxDelays}
+          /**
+           * always show current user at the top
+           *
+           */
+          countries={[{ ...userCountry, votes: voteState }, ...countries]}
+          device={device}
+        />
+      </Box>
     </Box>
   );
 };

--- a/beta-src/src/components/ui/WDPopover.tsx
+++ b/beta-src/src/components/ui/WDPopover.tsx
@@ -11,6 +11,7 @@ interface WDPopoverProps {
    * () => setIsOpen(false)
    */
   onClose?: ModalProps["onClose"];
+  open?: () => void;
   /**
    * A component that opens or closes the Popover when clicked.
    */
@@ -21,21 +22,18 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
   children,
   isOpen,
   onClose,
+  open,
   popoverTrigger,
 }) {
   const anchorEl = useRef(null);
-
   return (
-    <Box
-      sx={{
-        position: "absolute",
-      }}
-    >
+    <Box>
       <Box
-        ref={anchorEl}
         sx={{
           pt: "15px",
         }}
+        ref={anchorEl}
+        onClick={open}
       >
         {popoverTrigger}
       </Box>
@@ -68,8 +66,8 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
               content: '""',
               height: 22,
               position: "absolute",
-              right: 5,
-              top: 10,
+              right: 3,
+              top: 30,
               transform: "rotate(45deg)",
               width: 22,
             },
@@ -78,9 +76,9 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
 
         <Box
           sx={{
-            background: "linear-gradient(to right, white 94%, transparent 6%)",
+            background: "linear-gradient(to right, white 97%, transparent 3%)",
             m: 0,
-            p: "16px 25px 16px 16px",
+            p: "16px 9px 16px 0",
           }}
         >
           {children}
@@ -92,6 +90,7 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
 
 WDPopover.defaultProps = {
   onClose: undefined,
+  open: undefined,
 };
 
 export default WDPopover;

--- a/beta-src/src/components/ui/WDPress.tsx
+++ b/beta-src/src/components/ui/WDPress.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { Box } from "@mui/material";
+import Device from "../../enums/Device";
+
+interface WDPressProps {
+  children: React.ReactNode;
+  device: Device;
+}
+
+const WDPress: React.FC<WDPressProps> = function ({
+  children,
+  device,
+}): React.ReactElement {
+  const mobileLandscapeLayout =
+    device === Device.MOBILE_LANDSCAPE || device === Device.MOBILE_LG_LANDSCAPE;
+  const padding = mobileLandscapeLayout ? "0 6px" : "0 16px";
+  const minimumWidth = mobileLandscapeLayout ? 265 : 375;
+
+  return (
+    <Box
+      sx={{
+        m: "20px 0 10px 0",
+        p: padding,
+        minWidth: minimumWidth,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default WDPress;

--- a/beta-src/src/enums/ModalViews.ts
+++ b/beta-src/src/enums/ModalViews.ts
@@ -1,0 +1,7 @@
+enum ModalViews {
+  PRESS = "PRESS",
+  ORDERS = "ORDERS",
+  INFO = "INFO",
+}
+
+export default ModalViews;


### PR DESCRIPTION
# Testing link 

[testing link](https://fbfw-70.netlify.app/)

# Task Summary

- Create the full view of the info panel modal utilize already UI components build

  - On the modal display the following:

    - Title/Game Description
  
    - Pause/Cancel/Draw buttons
  
    - Table for info
  
    - Logic to display pause/cancel/draw interactions

  - Ensure modal is able to fit the content w/ proper spacing between elements above

- Add in panels to be selected to toggle between the views. Please add the following options to allow different selections:

  - “PRESS”

    - Should display a blank page

  - “INFO”

    - Should display contents of the info (as described above)
 
![209d3c8a-d70a-4688-a535-08893bed47bb](https://user-images.githubusercontent.com/99943146/160023343-2ff7840b-4e3f-4216-9a64-37cbd8e1482e.png)

![fc4fda7f-64fd-4b15-ad63-d7a24e0cb6ac](https://user-images.githubusercontent.com/99943146/160023373-09735f9b-762a-4051-be96-99fe7b530077.png)




