### PR TITLE
Feature/fbfw move order

### DIFF
--- a/beta-src/src/classes/map/TerritoryMapDataGenerator.ts
+++ b/beta-src/src/classes/map/TerritoryMapDataGenerator.ts
@@ -11,6 +11,8 @@ export default class TerritoryMapDataGenerator
 {
   public abbr: TerritoryMapData["abbr"];
 
+  public arrowReceiver: TerritoryMapData["arrowReceiver"];
+
   public centerPos: TerritoryMapData["centerPos"];
 
   public fill: TerritoryMapData["fill"];
@@ -39,6 +41,7 @@ export default class TerritoryMapDataGenerator
 
   constructor({
     abbr,
+    arrowReceiver = undefined,
     centerPos = undefined,
     country = undefined,
     fill = "none",
@@ -54,6 +57,7 @@ export default class TerritoryMapDataGenerator
     texture = undefined,
   }: TerritoryMapDataGeneratorInterface) {
     this.abbr = abbr;
+    this.arrowReceiver = arrowReceiver;
     this.centerPos = centerPos;
     this.fill = fill;
     this.height = height;
@@ -85,6 +89,7 @@ export default class TerritoryMapDataGenerator
   get territory(): TerritoryMapData {
     return {
       abbr: this.abbr,
+      arrowReceiver: this.arrowReceiver,
       centerPos: this.centerPos,
       fill: this.fill,
       height: this.height,

--- a/beta-src/src/components/map/WDMap.tsx
+++ b/beta-src/src/components/map/WDMap.tsx
@@ -3,12 +3,14 @@ import WDBoardMap from "./variants/classic/components/WDBoardMap";
 import CapturableLandTexture from "../../assets/textures/capturable-land.jpeg";
 import WaterTexture from "../../assets/textures/sea-texture.png";
 import WDCountryHighlightFilterDefs from "../../utils/map/WDCountryHighlightFilters";
+import WDArrowMarkerDefs from "../../utils/map/WDArrowMarkerDefs";
 
 const WDMap: React.ForwardRefExoticComponent<
   React.RefAttributes<SVGSVGElement>
 > = React.forwardRef(
   (_props, ref): React.ReactElement => (
     <svg
+      id="map"
       fill="none"
       ref={ref}
       style={{
@@ -46,6 +48,7 @@ const WDMap: React.ForwardRefExoticComponent<
           <image href={WaterTexture} x="0" y="0" width="1966" height="1615" />
         </pattern>
         {WDCountryHighlightFilterDefs()}
+        {WDArrowMarkerDefs()}
       </defs>
     </svg>
   ),

--- a/beta-src/src/components/map/components/WDTerritory.tsx
+++ b/beta-src/src/components/map/components/WDTerritory.tsx
@@ -64,7 +64,11 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
           break;
         case "CAPTURED":
           if (value.data?.country) {
-            setTerritoryFill(theme.palette[value.data.country].main);
+            if (value.data.country === "none") {
+              setTerritoryFill("none");
+            } else {
+              setTerritoryFill(theme.palette[value.data.country].main);
+            }
           } else {
             setTerritoryFill(theme.palette[userCountry].main);
           }
@@ -78,11 +82,12 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
     }
   }
 
-  const clickAction = function (clickObject: ClickObjectType) {
+  const clickAction = function (evt, clickObject: ClickObjectType) {
     dispatch(
       gameApiSliceActions.processMapClick({
-        name: territoryMapData.name,
         clickObject,
+        evt,
+        name: territoryMapData.name,
       }),
     );
   };
@@ -96,28 +101,29 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
       x={territoryMapData.x}
       y={territoryMapData.y}
     >
-      {territoryMapData.texture?.texture && (
+      <g onClick={(e) => clickAction(e, "territory")}>
+        {territoryMapData.texture?.texture && (
+          <path
+            d={territoryMapData.path}
+            fill={territoryMapData.texture.texture}
+            id={`${territoryMapData.name}-texture`}
+            stroke={territoryMapData.texture.stroke}
+            strokeOpacity={territoryMapData.texture.strokeOpacity}
+            strokeWidth={territoryMapData.texture.strokeWidth}
+          />
+        )}
         <path
           d={territoryMapData.path}
-          fill={territoryMapData.texture.texture}
-          id={`${territoryMapData.name}-texture`}
-          stroke={territoryMapData.texture.stroke}
-          strokeOpacity={territoryMapData.texture.strokeOpacity}
-          strokeWidth={territoryMapData.texture.strokeWidth}
+          fill={territoryFill}
+          fillOpacity={territoryFillOpacity}
+          id={`${territoryMapData.name}-control-path`}
+          stroke={theme.palette.primary.main}
+          strokeOpacity={1}
+          strokeWidth={territoryStrokeOpacity}
         />
-      )}
-      <path
-        d={territoryMapData.path}
-        fill={territoryFill}
-        fillOpacity={territoryFillOpacity}
-        id={`${territoryMapData.name}-control-path`}
-        onClick={() => clickAction("territory")}
-        stroke={theme.palette.primary.main}
-        strokeOpacity={1}
-        strokeWidth={territoryStrokeOpacity}
-      />
+      </g>
       {territoryMapData.centerPos && (
-        <g onClick={() => clickAction("center")}>
+        <g style={{ pointerEvents: "none" }}>
           <WDCenter
             territoryName={territoryMapData.name}
             x={territoryMapData.centerPos.x}
@@ -134,7 +140,7 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
             id = `${territoryMapData.name}-label-main`;
           }
           return (
-            <g onClick={() => clickAction("label")}>
+            <g style={{ pointerEvents: "none" }}>
               <WDLabel
                 id={id}
                 key={id || i}
@@ -156,6 +162,15 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
             y={unitSlot.y}
           />
         ))}
+      {territoryMapData.arrowReceiver && (
+        <rect
+          id={`${territoryMapData.name}-arrow-receiver`}
+          x={territoryMapData.arrowReceiver.x}
+          y={territoryMapData.arrowReceiver.y}
+          width="1"
+          height="1"
+        />
+      )}
     </svg>
   );
 };

--- a/beta-src/src/components/map/components/WDTerritory.tsx
+++ b/beta-src/src/components/map/components/WDTerritory.tsx
@@ -120,7 +120,7 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
         />
       </g>
       {territoryMapData.centerPos && (
-        <g style={{ pointerEvents: "none" }}>
+        <g className="no-pointer-events">
           <WDCenter
             territoryName={territoryMapData.name}
             x={territoryMapData.centerPos.x}
@@ -137,7 +137,7 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
             id = `${territoryMapData.name}-label-main`;
           }
           return (
-            <g style={{ pointerEvents: "none" }}>
+            <g className="no-pointer-events">
               <WDLabel
                 id={id}
                 key={id || i}

--- a/beta-src/src/components/svgr-components/WDArmyIcon.tsx
+++ b/beta-src/src/components/svgr-components/WDArmyIcon.tsx
@@ -8,6 +8,7 @@ const WDArmyIcon: React.FC<gameIconProps> = function ({
   country,
   height = 50,
   iconState = UIState.NONE,
+  id = undefined,
   meta,
   viewBox,
   width = 50,
@@ -19,6 +20,7 @@ const WDArmyIcon: React.FC<gameIconProps> = function ({
     <svg
       filter="drop-shadow(1px 4px 4px #323232)"
       height={height}
+      id={id}
       width={width}
       viewBox={viewBox}
     >

--- a/beta-src/src/components/svgr-components/WDFleetIcon.tsx
+++ b/beta-src/src/components/svgr-components/WDFleetIcon.tsx
@@ -8,6 +8,7 @@ const WDFleetIcon: React.FC<gameIconProps> = function ({
   country,
   height = 50,
   iconState = UIState.NONE,
+  id = undefined,
   meta,
   viewBox,
   width = 50,
@@ -19,6 +20,7 @@ const WDFleetIcon: React.FC<gameIconProps> = function ({
     <svg
       filter="drop-shadow(1px 4px 4px #323232)"
       height={height}
+      id={id}
       viewBox={viewBox}
       width={width}
     >

--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -13,7 +13,7 @@ import {
   gameOrdersMeta,
   saveOrders,
 } from "../../state/game/game-api-slice";
-import { IOrderData } from "../../models/Interfaces";
+import UpdateOrder from "../../interfaces/state/UpdateOrder";
 
 interface WDMoveControlsProps {
   gameState: MoveStatus;
@@ -52,21 +52,27 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
     if ("currentOrders" in data && "contextVars" in data) {
       const { currentOrders, contextVars } = data;
       if (contextVars && currentOrders) {
-        const orderUpdates: IOrderData[] = [];
-        currentOrders.forEach((o) => {
-          const updateReference = ordersMeta[o.id].update;
-          let orderUpdate: IOrderData = o;
-          if (updateReference) {
-            orderUpdate = {
-              ...o,
-              ...{
-                type: updateReference.type,
-                toTerrID: updateReference.toTerrID,
-              },
+        const orderUpdates: UpdateOrder[] = [];
+        currentOrders.forEach(
+          ({ fromTerrID, id, toTerrID, type: moveType, unitID, viaConvoy }) => {
+            const updateReference = ordersMeta[id].update;
+            let orderUpdate: UpdateOrder = {
+              fromTerrID,
+              id,
+              toTerrID,
+              type: moveType,
+              unitID,
+              viaConvoy,
             };
-          }
-          orderUpdates.push(orderUpdate);
-        });
+            if (updateReference) {
+              orderUpdate = {
+                ...orderUpdate,
+                ...updateReference,
+              };
+            }
+            orderUpdates.push(orderUpdate);
+          },
+        );
         const orderSubmission = {
           orderUpdates,
           context: contextVars.context,

--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -42,7 +42,7 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
       break;
   }
 
-  const click = (type: Move) => {
+  const clickButton = (type: Move) => {
     dispatch(
       gameApiSliceActions.processMapClick({
         name: undefined,
@@ -109,11 +109,11 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
       <WDButton
         color="primary"
         disabled={ready || !save}
-        onClick={() => click(Move.SAVE)}
+        onClick={() => clickButton(Move.SAVE)}
       >
         Save
       </WDButton>
-      <WDButton color="primary" onClick={() => click(Move.READY)}>
+      <WDButton color="primary" onClick={() => clickButton(Move.READY)}>
         {ready ? "Unready" : "Ready"}
       </WDButton>
     </Stack>

--- a/beta-src/src/components/ui/WDUnitController.tsx
+++ b/beta-src/src/components/ui/WDUnitController.tsx
@@ -76,8 +76,8 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
     }
     dispatch(
       gameApiSliceActions.processUnitClick({
-        unitID: meta.unit.id,
         onTerritory: meta.mappedTerritory.territory,
+        unitID: meta.unit.id,
       }),
     );
   };

--- a/beta-src/src/components/ui/WDUnitController.tsx
+++ b/beta-src/src/components/ui/WDUnitController.tsx
@@ -30,10 +30,12 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
 
   const order = useAppSelector(gameOrder);
 
-  if (order.unitID === meta.unit.id) {
-    setIconState(UIState.SELECTED);
-  } else {
-    setIconState(UIState.NONE);
+  if (!order.type) {
+    if (order.unitID === meta.unit.id) {
+      setIconState(UIState.SELECTED);
+    } else {
+      setIconState(UIState.NONE);
+    }
   }
 
   const commandActions = {

--- a/beta-src/src/data/map/land/LandTerritoriesMapData.ts
+++ b/beta-src/src/data/map/land/LandTerritoriesMapData.ts
@@ -6,6 +6,10 @@ import Territory from "../../../enums/map/variants/classic/Territory";
 
 export const ALBANIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ALBANIA).territory,
+  arrowReceiver: {
+    x: 43,
+    y: 127,
+  },
   fill: "none",
   labels: [
     {
@@ -32,6 +36,10 @@ export const ALBANIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const ANKARA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ANKARA).territory,
+  arrowReceiver: {
+    x: 40,
+    y: 80,
+  },
   centerPos: {
     x: 60,
     y: 100,
@@ -62,6 +70,10 @@ export const ANKARA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const APULIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.APULIA).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 95,
+  },
   fill: "none",
   labels: [
     {
@@ -88,6 +100,10 @@ export const APULIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const ARMENIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ARMENIA).territory,
+  arrowReceiver: {
+    x: 60,
+    y: 75,
+  },
   fill: "none",
   labels: [
     {
@@ -114,6 +130,10 @@ export const ARMENIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BELGIUM: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BELGIUM).territory,
+  arrowReceiver: {
+    x: 117,
+    y: 70,
+  },
   centerPos: {
     x: 75,
     y: 20,
@@ -144,6 +164,10 @@ export const BELGIUM: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BERLIN: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BERLIN).territory,
+  arrowReceiver: {
+    x: 50,
+    y: 45,
+  },
   centerPos: {
     x: 57,
     y: 93,
@@ -174,6 +198,10 @@ export const BERLIN: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BOHEMIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BOHEMIA).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 50,
+  },
   fill: "none",
   labels: [
     {
@@ -200,6 +228,10 @@ export const BOHEMIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BREST: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BREST).territory,
+  arrowReceiver: {
+    x: 120,
+    y: 145,
+  },
   centerPos: {
     x: 15,
     y: 35,
@@ -230,6 +262,10 @@ export const BREST: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BUDAPEST: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BUDAPEST).territory,
+  arrowReceiver: {
+    x: 165,
+    y: 150,
+  },
   centerPos: {
     x: 67,
     y: 85,
@@ -260,6 +296,10 @@ export const BUDAPEST: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BULGARIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BULGARIA).territory,
+  arrowReceiver: {
+    x: 125,
+    y: 75,
+  },
   centerPos: {
     x: 20,
     y: 65,
@@ -310,6 +350,10 @@ export const BULGARIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BURGUNDY: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BURGUNDY).territory,
+  arrowReceiver: {
+    x: 70,
+    y: 160,
+  },
   fill: "none",
   labels: [
     {
@@ -336,6 +380,10 @@ export const BURGUNDY: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const CLYDE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.CLYDE).territory,
+  arrowReceiver: {
+    x: 50,
+    y: 45,
+  },
   fill: "none",
   labels: [
     {
@@ -362,6 +410,10 @@ export const CLYDE: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const CONSTANTINOPLE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.CONSTANTINOPLE).territory,
+  arrowReceiver: {
+    x: 155,
+    y: 110,
+  },
   centerPos: {
     x: 60,
     y: 22,
@@ -392,6 +444,10 @@ export const CONSTANTINOPLE: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const DENMARK: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.DENMARK).territory,
+  arrowReceiver: {
+    x: 45,
+    y: 45,
+  },
   centerPos: {
     x: 99,
     y: 103,
@@ -422,6 +478,10 @@ export const DENMARK: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const EDINBURGH: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.EDINBURGH).territory,
+  arrowReceiver: {
+    x: 25,
+    y: 125,
+  },
   centerPos: {
     x: 22,
     y: 155,
@@ -452,6 +512,10 @@ export const EDINBURGH: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const FINLAND: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.FINLAND).territory,
+  arrowReceiver: {
+    x: 120,
+    y: 330,
+  },
   fill: "none",
   labels: [
     {
@@ -478,6 +542,10 @@ export const FINLAND: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const GALICIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.GALICIA).territory,
+  arrowReceiver: {
+    x: 130,
+    y: 45,
+  },
   fill: "none",
   labels: [
     {
@@ -504,6 +572,10 @@ export const GALICIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const GASCONY: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.GASCONY).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 80,
+  },
   fill: "none",
   labels: [
     {
@@ -530,6 +602,10 @@ export const GASCONY: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const GREECE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.GREECE).territory,
+  arrowReceiver: {
+    x: 95,
+    y: 160,
+  },
   fill: "none",
   labels: [
     {
@@ -556,6 +632,10 @@ export const GREECE: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const HOLLAND: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.HOLLAND).territory,
+  arrowReceiver: {
+    x: 75,
+    y: 35,
+  },
   centerPos: {
     x: 82,
     y: 5,
@@ -586,6 +666,10 @@ export const HOLLAND: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const KIEL: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.KIEL).territory,
+  arrowReceiver: {
+    x: 128,
+    y: 105,
+  },
   centerPos: {
     x: 130,
     y: 73,
@@ -616,6 +700,10 @@ export const KIEL: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const LIVERPOOL: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.LIVERPOOL).territory,
+  arrowReceiver: {
+    x: 75,
+    y: 155,
+  },
   centerPos: {
     x: 51,
     y: 159,
@@ -646,6 +734,10 @@ export const LIVERPOOL: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const LIVONIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.LIVONIA).territory,
+  arrowReceiver: {
+    x: 130,
+    y: 210,
+  },
   fill: "none",
   labels: [
     {
@@ -672,6 +764,10 @@ export const LIVONIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const LONDON: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.LONDON).territory,
+  arrowReceiver: {
+    x: 55,
+    y: 60,
+  },
   centerPos: {
     x: 28,
     y: 62,
@@ -702,6 +798,10 @@ export const LONDON: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const MARSEILLES: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.MARSEILLES).territory,
+  arrowReceiver: {
+    x: 180,
+    y: 65,
+  },
   centerPos: {
     x: 160,
     y: 110,
@@ -732,6 +832,10 @@ export const MARSEILLES: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const MOSCOW: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.MOSCOW).territory,
+  arrowReceiver: {
+    x: 420,
+    y: 400,
+  },
   centerPos: {
     x: "45%",
     y: "45.3%",
@@ -762,6 +866,10 @@ export const MOSCOW: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const MUNICH: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.MUNICH).territory,
+  arrowReceiver: {
+    x: 170,
+    y: 150,
+  },
   centerPos: {
     x: 154,
     y: 160,
@@ -792,6 +900,10 @@ export const MUNICH: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NAPLES: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NAPLES).territory,
+  arrowReceiver: {
+    x: 45,
+    y: 38,
+  },
   centerPos: {
     x: 7,
     y: 10,
@@ -939,6 +1051,10 @@ export const NEUTRAL_9: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NORTH_AFRICA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NORTH_AFRICA).territory,
+  arrowReceiver: {
+    x: 570,
+    y: 150,
+  },
   labels: [
     {
       x: 430,
@@ -965,6 +1081,10 @@ export const NORTH_AFRICA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NORWAY: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NORWAY).territory,
+  arrowReceiver: {
+    x: 75,
+    y: 585,
+  },
   centerPos: {
     x: 140,
     y: 540,
@@ -995,6 +1115,10 @@ export const NORWAY: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const PARIS: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.PARIS).territory,
+  arrowReceiver: {
+    x: 100,
+    y: 60,
+  },
   centerPos: {
     x: 81,
     y: 9,
@@ -1025,6 +1149,10 @@ export const PARIS: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const PICARDY: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.PICARDY).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 45,
+  },
   fill: "none",
   labels: [
     {
@@ -1051,6 +1179,10 @@ export const PICARDY: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const PIEDMONT: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.PIEDMONT).territory,
+  arrowReceiver: {
+    x: 50,
+    y: 75,
+  },
   fill: "none",
   labels: [
     {
@@ -1077,6 +1209,10 @@ export const PIEDMONT: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const PORTUGAL: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.PORTUGAL).territory,
+  arrowReceiver: {
+    x: 60,
+    y: 120,
+  },
   centerPos: {
     x: 13,
     y: 128,
@@ -1107,6 +1243,10 @@ export const PORTUGAL: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const PRUSSIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.PRUSSIA).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 140,
+  },
   fill: "none",
   labels: [
     {
@@ -1133,6 +1273,10 @@ export const PRUSSIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const ROME: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ROME).territory,
+  arrowReceiver: {
+    x: 42,
+    y: 30,
+  },
   centerPos: {
     x: 10,
     y: 23,
@@ -1163,6 +1307,10 @@ export const ROME: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const RUHR: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.RUHR).territory,
+  arrowReceiver: {
+    x: 55,
+    y: 45,
+  },
   fill: "none",
   labels: [
     {
@@ -1189,6 +1337,10 @@ export const RUHR: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const RUMANIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.RUMANIA).territory,
+  arrowReceiver: {
+    x: 120,
+    y: 170,
+  },
   centerPos: {
     x: 140,
     y: 180,
@@ -1220,6 +1372,10 @@ export const RUMANIA: TerritoryMapData = new TerritoryMapDataGenerator({
 export const SAINT_PETERSBURG: TerritoryMapData = new TerritoryMapDataGenerator(
   {
     ...new TerritoryDataGenerator(Territory.SAINT_PETERSBURG).territory,
+    arrowReceiver: {
+      x: 330,
+      y: 540,
+    },
     centerPos: {
       x: "20%",
       y: "78%",
@@ -1271,6 +1427,10 @@ export const SAINT_PETERSBURG: TerritoryMapData = new TerritoryMapDataGenerator(
 
 export const SERBIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SERBIA).territory,
+  arrowReceiver: {
+    x: 50,
+    y: 90,
+  },
   centerPos: {
     x: 35,
     y: 10,
@@ -1301,6 +1461,10 @@ export const SERBIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SEVASTOPOL: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SEVASTOPOL).territory,
+  arrowReceiver: {
+    x: 300,
+    y: 200,
+  },
   centerPos: {
     x: 209,
     y: 410,
@@ -1331,6 +1495,10 @@ export const SEVASTOPOL: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SILESIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SILESIA).territory,
+  arrowReceiver: {
+    x: 65,
+    y: 50,
+  },
   fill: "none",
   labels: [
     {
@@ -1357,6 +1525,10 @@ export const SILESIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SMYRNA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SMYRNA).territory,
+  arrowReceiver: {
+    x: 85,
+    y: 200,
+  },
   centerPos: {
     x: 20,
     y: 150,
@@ -1387,6 +1559,10 @@ export const SMYRNA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SPAIN: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SPAIN).territory,
+  arrowReceiver: {
+    x: 200,
+    y: 275,
+  },
   centerPos: {
     x: 177,
     y: 190,
@@ -1437,6 +1613,10 @@ export const SPAIN: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SWEDEN: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SWEDEN).territory,
+  arrowReceiver: {
+    x: 100,
+    y: 530,
+  },
   centerPos: {
     x: 160,
     y: 470,
@@ -1467,6 +1647,10 @@ export const SWEDEN: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SYRIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SYRIA).territory,
+  arrowReceiver: {
+    x: 100,
+    y: 100,
+  },
   fill: "none",
   labels: [
     {
@@ -1493,6 +1677,10 @@ export const SYRIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const TRIESTE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.TRIESTE).territory,
+  arrowReceiver: {
+    x: 100,
+    y: 60,
+  },
   centerPos: {
     x: 56,
     y: 70,
@@ -1523,6 +1711,10 @@ export const TRIESTE: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const TUNIS: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.TUNIS).territory,
+  arrowReceiver: {
+    x: 95,
+    y: 50,
+  },
   centerPos: {
     x: 100,
     y: 20,
@@ -1553,6 +1745,10 @@ export const TUNIS: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const TUSCANY: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.TUSCANY).territory,
+  arrowReceiver: {
+    x: 50,
+    y: 90,
+  },
   fill: "none",
   labels: [
     {
@@ -1579,6 +1775,10 @@ export const TUSCANY: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const TYROLIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.TYROLIA).territory,
+  arrowReceiver: {
+    x: 160,
+    y: 60,
+  },
   fill: "none",
   labels: [
     {
@@ -1605,6 +1805,10 @@ export const TYROLIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const UKRAINE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.UKRAINE).territory,
+  arrowReceiver: {
+    x: 150,
+    y: 150,
+  },
   fill: "none",
   labels: [
     {
@@ -1751,6 +1955,10 @@ export const UNPLAYABLE_LAND8: TerritoryMapData = new TerritoryMapDataGenerator(
 
 export const VIENNA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.VIENNA).territory,
+  arrowReceiver: {
+    x: 65,
+    y: 45,
+  },
   centerPos: {
     x: 28,
     y: 48,
@@ -1781,6 +1989,10 @@ export const VIENNA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const VENICE: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.VENICE).territory,
+  arrowReceiver: {
+    x: 65,
+    y: 65,
+  },
   centerPos: {
     x: 68,
     y: 29,
@@ -1811,6 +2023,10 @@ export const VENICE: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const WALES: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.WALES).territory,
+  arrowReceiver: {
+    x: 125,
+    y: 55,
+  },
   fill: "none",
   labels: [
     {
@@ -1837,6 +2053,10 @@ export const WALES: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const WARSAW: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.WARSAW).territory,
+  arrowReceiver: {
+    x: 130,
+    y: 135,
+  },
   centerPos: {
     x: 65,
     y: 75,
@@ -1867,6 +2087,10 @@ export const WARSAW: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const YORK: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.YORK).territory,
+  arrowReceiver: {
+    x: 25,
+    y: 125,
+  },
   fill: "none",
   labels: [
     {

--- a/beta-src/src/data/map/sea/SeaTerritoriesMapData.ts
+++ b/beta-src/src/data/map/sea/SeaTerritoriesMapData.ts
@@ -6,6 +6,10 @@ import Texture from "../../../enums/Texture";
 
 export const ADRIATIC_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ADRIATIC_SEA).territory,
+  arrowReceiver: {
+    x: 160,
+    y: 180,
+  },
   fill: "none",
   labels: [
     {
@@ -32,6 +36,10 @@ export const ADRIATIC_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const AEGEAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.AEGEAN_SEA).territory,
+  arrowReceiver: {
+    x: 120,
+    y: 200,
+  },
   fill: "none",
   labels: [
     {
@@ -58,6 +66,10 @@ export const AEGEAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BALTIC_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BALTIC_SEA).territory,
+  arrowReceiver: {
+    x: 200,
+    y: 150,
+  },
   fill: "none",
   labels: [
     {
@@ -84,6 +96,10 @@ export const BALTIC_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BARENTS_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BARENTS_SEA).territory,
+  arrowReceiver: {
+    x: 250,
+    y: 100,
+  },
   fill: "none",
   labels: [
     {
@@ -110,6 +126,10 @@ export const BARENTS_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const BLACK_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.BLACK_SEA).territory,
+  arrowReceiver: {
+    x: 150,
+    y: 250,
+  },
   fill: "none",
   labels: [
     {
@@ -150,6 +170,10 @@ export const CHANNEL_1: TerritoryMapData = new TerritoryMapDataGenerator({
 export const EASTERN_MEDITERRANEAN: TerritoryMapData =
   new TerritoryMapDataGenerator({
     ...new TerritoryDataGenerator(Territory.EASTERN_MEDITERRANEAN).territory,
+    arrowReceiver: {
+      x: 300,
+      y: 165,
+    },
     fill: "none",
     labels: [
       {
@@ -176,6 +200,10 @@ export const EASTERN_MEDITERRANEAN: TerritoryMapData =
 
 export const ENGLISH_CHANNEL: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.ENGLISH_CHANNEL).territory,
+  arrowReceiver: {
+    x: 95,
+    y: 50,
+  },
   fill: "none",
   labels: [
     {
@@ -202,6 +230,10 @@ export const ENGLISH_CHANNEL: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const GULF_OF_BOTHNIA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.GULF_OF_BOTHNIA).territory,
+  arrowReceiver: {
+    x: 110,
+    y: 375,
+  },
   fill: "none",
   labels: [
     {
@@ -228,6 +260,10 @@ export const GULF_OF_BOTHNIA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const GULF_OF_LYONS: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.GULF_OF_LYONS).territory,
+  arrowReceiver: {
+    x: 240,
+    y: 150,
+  },
   fill: "none",
   labels: [
     {
@@ -255,6 +291,10 @@ export const GULF_OF_LYONS: TerritoryMapData = new TerritoryMapDataGenerator({
 export const HELIGOLAND_BIGHT: TerritoryMapData = new TerritoryMapDataGenerator(
   {
     ...new TerritoryDataGenerator(Territory.HELIGOLAND_BIGHT).territory,
+    arrowReceiver: {
+      x: 50,
+      y: 100,
+    },
     labels: [
       {
         x: 45,
@@ -281,6 +321,10 @@ export const HELIGOLAND_BIGHT: TerritoryMapData = new TerritoryMapDataGenerator(
 
 export const IONIAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.IONIAN_SEA).territory,
+  arrowReceiver: {
+    x: 330,
+    y: 140,
+  },
   fill: "none",
   labels: [
     {
@@ -307,6 +351,10 @@ export const IONIAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const IRISH_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.IRISH_SEA).territory,
+  arrowReceiver: {
+    x: 75,
+    y: 175,
+  },
   fill: "none",
   labels: [
     {
@@ -333,6 +381,10 @@ export const IRISH_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const MIDDLE_ATLANTIC: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.MIDDLE_ATLANTIC).territory,
+  arrowReceiver: {
+    x: 450,
+    y: 300,
+  },
   fill: "none",
   labels: [
     {
@@ -359,6 +411,10 @@ export const MIDDLE_ATLANTIC: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NORTH_ATLANTIC: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NORTH_ATLANTIC).territory,
+  arrowReceiver: {
+    x: 300,
+    y: 600,
+  },
   fill: "none",
   labels: [
     {
@@ -398,6 +454,10 @@ export const NORTH_ATLANTIC2: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NORTH_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NORTH_SEA).territory,
+  arrowReceiver: {
+    x: 150,
+    y: 300,
+  },
   fill: "none",
   labels: [
     {
@@ -424,6 +484,10 @@ export const NORTH_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const NORWEGIAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.NORWEGIAN_SEA).territory,
+  arrowReceiver: {
+    x: 400,
+    y: 400,
+  },
   fill: "none",
   labels: [
     {
@@ -450,6 +514,10 @@ export const NORWEGIAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const SKAGERRACK: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.SKAGERRACK).territory,
+  arrowReceiver: {
+    x: 35,
+    y: 80,
+  },
   fill: "none",
   labels: [
     {
@@ -489,6 +557,10 @@ export const SKAGERRACK2: TerritoryMapData = new TerritoryMapDataGenerator({
 
 export const TYRRHENIAN_SEA: TerritoryMapData = new TerritoryMapDataGenerator({
   ...new TerritoryDataGenerator(Territory.TYRRHENIAN_SEA).territory,
+  arrowReceiver: {
+    x: 100,
+    y: 200,
+  },
   fill: "none",
   labels: [
     {
@@ -633,6 +705,10 @@ export const UNPLAYABLE_SEA9: TerritoryMapData = new TerritoryMapDataGenerator({
 export const WESTERN_MEDITERRANEAN: TerritoryMapData =
   new TerritoryMapDataGenerator({
     ...new TerritoryDataGenerator(Territory.WESTERN_MEDITERRANEAN).territory,
+    arrowReceiver: {
+      x: 350,
+      y: 100,
+    },
     fill: "none",
     labels: [
       {

--- a/beta-src/src/interfaces/Icons.ts
+++ b/beta-src/src/interfaces/Icons.ts
@@ -10,6 +10,7 @@ export interface gameIconProps {
   country: Country;
   height?: number;
   iconState?: UIState;
+  id?: string;
   viewBox?: string;
   width?: number;
   meta: UnitMeta;

--- a/beta-src/src/interfaces/index.ts
+++ b/beta-src/src/interfaces/index.ts
@@ -11,3 +11,4 @@ export * from "./map/Texture";
 export * from "./map/UnitSlot";
 export * from "./state/MemberData";
 export * from "./map/UnitMeta";
+export * from "./state/UpdateOrder";

--- a/beta-src/src/interfaces/map/TerritoryMapData.ts
+++ b/beta-src/src/interfaces/map/TerritoryMapData.ts
@@ -1,6 +1,7 @@
 import {
   AbsoluteCoordinates,
   BBox,
+  Coordinates,
   Label,
   Territory,
   Texture,
@@ -8,6 +9,7 @@ import {
 } from "..";
 
 export interface TerritoryMapData extends Territory, BBox {
+  arrowReceiver?: Coordinates;
   centerPos?: AbsoluteCoordinates;
   fill?: string;
   labels?: Label[];

--- a/beta-src/src/interfaces/state/UpdateOrder.ts
+++ b/beta-src/src/interfaces/state/UpdateOrder.ts
@@ -1,0 +1,8 @@
+export default interface UpdateOrder {
+  fromTerrID: string | null;
+  id: string;
+  toTerrID: string | null;
+  type: string;
+  unitID: string;
+  viaConvoy: string | null;
+}

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -250,13 +250,15 @@ const gameApiSlice = createSlice({
               return o.unitID === currOrderUnitID;
             });
             if (orderToUpdate) {
-              state.ordersMeta[orderToUpdate.id] = {
-                saved: false,
-                update: {
-                  type: "Hold",
-                  toTerrID: null,
+              updateOrdersMeta(state, {
+                [orderToUpdate.id]: {
+                  saved: false,
+                  update: {
+                    type: "Hold",
+                    toTerrID: null,
+                  },
                 },
-              };
+              });
             }
           }
           state.order.type = "hold";
@@ -305,14 +307,16 @@ const gameApiSlice = createSlice({
             };
             setCommand(state, command, "territoryCommands", territoryName);
             const update: EditOrderMeta = {};
-            update[order.orderID] = {
-              saved: false,
-              update: {
-                type: "Move",
-                toTerrID: canMove.id,
-                viaConvoy: "No",
+            updateOrdersMeta(state, {
+              [order.orderID]: {
+                saved: false,
+                update: {
+                  type: "Move",
+                  toTerrID: canMove.id,
+                  viaConvoy: "No",
+                },
               },
-            };
+            });
             updateOrdersMeta(state, update);
             state.order.toTerritory = toTerritory;
             state.order.type = "move";

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -7,19 +7,19 @@ import GameErrorResponse from "../interfaces/GameErrorResponse";
 import GameOverviewResponse from "../interfaces/GameOverviewResponse";
 import GameCommands, {
   GameCommand,
-  GameContainerType,
+  GameCommandType,
 } from "../interfaces/GameCommands";
 import { ApiStatus } from "../interfaces/GameState";
 import GameStatusResponse from "../interfaces/GameStatusResponse";
 import { RootState } from "../store";
 import initialState from "./initial-state";
-import { IOrderData } from "../../models/Interfaces";
+import { ITerritory } from "../../models/Interfaces";
 import Territory from "../../enums/map/variants/classic/Territory";
-import OrdersMeta from "../interfaces/SavedOrders";
+import OrdersMeta, { EditOrderMeta } from "../interfaces/SavedOrders";
 import TerritoryMap from "../../data/map/variants/classic/TerritoryMap";
 import countryMap from "../../data/map/variants/classic/CountryMap";
 import OrderState from "../interfaces/OrderState";
-import GameCommandType from "../../types/state/GameCommandType";
+import UpdateOrder from "../../interfaces/state/UpdateOrder";
 
 export const fetchGameData = createAsyncThunk(
   ApiRoute.GAME_DATA,
@@ -48,7 +48,7 @@ export const fetchGameStatus = createAsyncThunk(
 );
 
 interface OrderSubmission {
-  orderUpdates: IOrderData[];
+  orderUpdates: UpdateOrder[];
   context: string;
   contextKey: string;
 }
@@ -81,6 +81,11 @@ interface NewOrderPayload {
   payload: OrderState;
 }
 
+interface UpdateOrdersMetaAction {
+  type: string;
+  payload: EditOrderMeta;
+}
+
 export const saveOrders = createAsyncThunk(
   "game/submitOrders",
   async (data: OrderSubmission) => {
@@ -107,7 +112,9 @@ export const saveOrders = createAsyncThunk(
 const resetOrder = (state) => {
   state.order.inProgress = false;
   state.order.unitID = "";
+  state.order.orderID = "";
   state.order.onTerritory = 0;
+  state.order.toTerritory = 0;
   delete state.order.type;
 };
 
@@ -115,16 +122,25 @@ const startNewOrder = (
   state,
   { payload: { unitID, onTerritory } }: NewOrderPayload,
 ) => {
+  const {
+    data: { data: gameData },
+  } = current(state);
+  const { currentOrders } = gameData;
+  const orderForUnit = currentOrders.find((order) => {
+    return order.unitID === unitID;
+  });
   state.order.inProgress = true;
   state.order.unitID = unitID;
+  state.order.orderID = orderForUnit.id;
   state.order.onTerritory = onTerritory;
+  state.order.toTerritory = null;
   delete state.order.type;
 };
 
 const setCommand = (
   state,
   command: GameCommand,
-  container: GameContainerType,
+  container: GameCommandType,
   id: string,
 ) => {
   const { commands } = current(state);
@@ -134,73 +150,102 @@ const setCommand = (
   state.commands[container][id] = newCommand;
 };
 
+const updateOrdersMeta = (state, updates: EditOrderMeta) => {
+  Object.entries(updates).forEach(([orderID, update]) => {
+    state.ordersMeta[orderID] = {
+      ...state.ordersMeta[orderID],
+      ...update,
+    };
+  });
+};
+
+const highlightMapTerritoriesBasedOnStatuses = (
+  state,
+  filter: Territory[] = [],
+) => {
+  const {
+    data: { data: gameData },
+    overview: { members },
+  } = current(state);
+  if ("territories" in gameData && gameData.territories) {
+    const membersMap = {};
+    members.forEach((member) => {
+      membersMap[member.countryID] = member.country;
+    });
+    const t: ITerritory[] = Object.values(gameData.territories);
+    t.forEach(({ countryID, name }) => {
+      const country = membersMap[countryID];
+      const mappedTerritory = TerritoryMap[name];
+      if (filter.length && !filter.includes(mappedTerritory.territory)) {
+        return;
+      }
+      const terrEnum = Territory[mappedTerritory.territory];
+      if (terrEnum) {
+        const command: GameCommand = {
+          command: "CAPTURED",
+          data: { country: country ? countryMap[country] : "none" },
+        };
+        setCommand(state, command, "territoryCommands", terrEnum);
+      }
+    });
+  }
+};
+
 const gameApiSlice = createSlice({
   name: "game",
   initialState,
   reducers: {
-    markOrdersAsSaved(state, orderIds) {
-      const {
-        data: { data: gameData },
-      } = current(state);
-      if ("currentOrders" in gameData && gameData.currentOrders) {
-        gameData.currentOrders.forEach((order) => {
-          if (orderIds.payload.includes(order.id)) {
-            if (!state.ordersMeta[order.id]) {
-              state.ordersMeta[order.id] = {
-                saved: true,
-              };
-            } else {
-              state.ordersMeta[order.id].saved = true;
-            }
-          }
-        });
-      }
+    updateOrdersMeta(state, action: UpdateOrdersMetaAction) {
+      updateOrdersMeta(state, action.payload);
     },
     processUnitClick(state, clickData) {
-      const { order, data: gameData } = current(state);
+      const { order } = current(state);
       const { inProgress } = order;
       if (inProgress) {
-        if (order.type === "hold") {
-          const holdOrderTerritory = Territory[state.order.onTerritory];
-          const command: GameCommand = {
-            command: "CAPTURED",
-          };
-          setCommand(state, command, "territoryCommands", holdOrderTerritory);
+        if (order.type === "hold" && order.onTerritory !== null) {
+          highlightMapTerritoriesBasedOnStatuses(state);
+        } else if (order.type === "move" && order.toTerritory !== null) {
+          highlightMapTerritoriesBasedOnStatuses(state);
         }
       }
       if (inProgress && order.unitID === clickData.payload.unitID) {
         resetOrder(state);
       } else if (inProgress && order.unitID !== clickData.payload.unitID) {
         startNewOrder(state, clickData);
-      } else if (
-        !inProgress &&
-        "territoryStatuses" in gameData.data &&
-        "territories" in gameData.data &&
-        "contextVars" in gameData.data &&
-        "units" in gameData.data &&
-        gameData.data.contextVars &&
-        gameData.data.currentOrders
-      ) {
+      } else {
         startNewOrder(state, clickData);
       }
     },
     processMapClick(state, clickData) {
-      const { order, data } = current(state);
+      const {
+        data: { data: gameData },
+        order,
+        ordersMeta,
+      } = current(state);
+      const {
+        payload: { clickObject, evt, name: territoryName },
+      } = clickData;
       if (order.inProgress) {
-        const territoryName = clickData.payload.name;
-        const currOrderUnitID = state.order.unitID;
+        const currOrderUnitID = order.unitID;
         if (
+          order.onTerritory !== null &&
           Territory[order.onTerritory] === territoryName &&
-          !state.order.type
+          !order.type
         ) {
-          const holdCommand: GameCommand = {
+          let command: GameCommand = {
             command: "HOLD",
           };
-          setCommand(state, holdCommand, "territoryCommands", territoryName);
-          setCommand(state, holdCommand, "unitCommands", currOrderUnitID);
-
-          if ("currentOrders" in data.data) {
-            const { currentOrders } = data.data;
+          setCommand(state, command, "territoryCommands", territoryName);
+          setCommand(state, command, "unitCommands", currOrderUnitID);
+          command = {
+            command: "REMOVE_ARROW",
+            data: {
+              orderID: order.orderID,
+            },
+          };
+          setCommand(state, command, "mapCommands", "all");
+          if ("currentOrders" in gameData) {
+            const { currentOrders } = gameData;
             const orderToUpdate = currentOrders?.find((o) => {
               return o.unitID === currOrderUnitID;
             });
@@ -215,13 +260,74 @@ const gameApiSlice = createSlice({
             }
           }
           state.order.type = "hold";
-        } else if (state.order.type === "hold") {
-          const holdOrderTerritory = Territory[state.order.onTerritory];
-          const command: GameCommand = {
-            command: "CAPTURED",
-          };
-          setCommand(state, command, "territoryCommands", holdOrderTerritory);
+        } else if (order.onTerritory !== null && order.type === "hold") {
+          highlightMapTerritoriesBasedOnStatuses(state);
           resetOrder(state);
+        } else if (order.toTerritory !== null && order.type === "move") {
+          highlightMapTerritoriesBasedOnStatuses(state);
+          resetOrder(state);
+        } else if (
+          clickObject === "territory" &&
+          order.onTerritory !== null &&
+          Territory[order.onTerritory] !== territoryName &&
+          !order.type &&
+          order.inProgress
+        ) {
+          const { allowedBorderCrossings } = ordersMeta[order.orderID];
+          const canMove = allowedBorderCrossings?.find((border) => {
+            const mappedTerritory = TerritoryMap[border.name];
+            return Territory[mappedTerritory.territory] === territoryName;
+          });
+          if (canMove) {
+            const toTerritory = Number(Territory[territoryName]);
+            let command: GameCommand = {
+              command: "REMOVE_ARROW",
+              data: {
+                orderID: order.orderID,
+              },
+            };
+            highlightMapTerritoriesBasedOnStatuses(state);
+            setCommand(state, command, "mapCommands", "all");
+            command = {
+              command: "DRAW_ARROW",
+              data: {
+                orderID: order.orderID,
+                arrow: {
+                  from: order.onTerritory,
+                  to: toTerritory,
+                  type: "move",
+                },
+              },
+            };
+            setCommand(state, command, "mapCommands", "all");
+            command = {
+              command: "HOLD",
+            };
+            setCommand(state, command, "territoryCommands", territoryName);
+            const update: EditOrderMeta = {};
+            update[order.orderID] = {
+              saved: false,
+              update: {
+                type: "Move",
+                toTerrID: canMove.id,
+                viaConvoy: "No",
+              },
+            };
+            updateOrdersMeta(state, update);
+            state.order.toTerritory = toTerritory;
+            state.order.type = "move";
+          } else {
+            const command: GameCommand = {
+              command: "INVALID_CLICK",
+              data: {
+                click: {
+                  evt,
+                  territoryName,
+                },
+              },
+            };
+            setCommand(state, command, "mapCommands", "all");
+          }
         }
       }
     },
@@ -240,36 +346,7 @@ const gameApiSlice = createSlice({
       }
     },
     highlightMapTerritories(state) {
-      const {
-        data,
-        overview: { members },
-      } = current(state);
-      if (
-        "territoryStatuses" in data.data &&
-        "territories" in data.data &&
-        data.data.territoryStatuses
-      ) {
-        const membersMap = {};
-        const t = data.data.territories;
-        const tS = data.data.territoryStatuses;
-        members.forEach((member) => {
-          membersMap[member.countryID] = member.country;
-        });
-        tS.forEach((status) => {
-          const terr = t[status.id];
-          if (!status.ownerCountryID) {
-            return;
-          }
-          const country = membersMap[status.ownerCountryID];
-          const mappedTerritory = TerritoryMap[terr.name];
-          const terrEnum = Territory[mappedTerritory.territory];
-          const command: GameCommand = {
-            command: "CAPTURED",
-            data: { country: countryMap[country] },
-          };
-          setCommand(state, command, "territoryCommands", terrEnum);
-        });
-      }
+      highlightMapTerritoriesBasedOnStatuses(state);
     },
   },
   extraReducers(builder) {
@@ -316,9 +393,7 @@ const gameApiSlice = createSlice({
           const { orders } = action.payload;
           Object.entries(orders).forEach(([id, value]) => {
             if (value.status === "Complete") {
-              state.ordersMeta[id] = {
-                saved: true,
-              };
+              state.ordersMeta[id].saved = true;
             }
           });
         }

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -17,13 +17,16 @@ const initialState: GameState = {
   error: null,
   order: {
     inProgress: false,
+    onTerritory: null,
+    orderID: "",
+    toTerritory: null,
     unitID: "",
-    onTerritory: 0,
   },
   ordersMeta: {},
   commands: {
-    unitCommands: {},
+    mapCommands: {},
     territoryCommands: {},
+    unitCommands: {},
   },
   overview: {
     alternatives: "",

--- a/beta-src/src/state/interfaces/GameCommands.ts
+++ b/beta-src/src/state/interfaces/GameCommands.ts
@@ -1,11 +1,31 @@
 import Country from "../../enums/Country";
+import Territory from "../../enums/map/variants/classic/Territory";
 
-type Command = "HOLD" | "CAPTURED";
+type Command =
+  | "HOLD"
+  | "CAPTURED"
+  | "DRAW_ARROW"
+  | "REMOVE_ARROW"
+  | "INVALID_CLICK";
+
+interface DrawArrowCommand {
+  from: Territory;
+  to: Territory;
+  type: "move";
+}
+
+interface ClickCommand {
+  evt: unknown;
+  territoryName: string;
+}
 
 export interface GameCommand {
   command: Command;
   data?: {
-    country?: keyof Country;
+    click?: ClickCommand;
+    orderID?: string;
+    country?: keyof Country | "none";
+    arrow?: DrawArrowCommand;
   };
 }
 
@@ -13,10 +33,13 @@ export interface GameCommandContainer {
   [key: string]: Map<string, GameCommand>;
 }
 
-export type GameContainerType = "territoryCommands" | "unitCommands";
+export type GameCommandType =
+  | "territoryCommands"
+  | "unitCommands"
+  | "mapCommands";
 
 type GameCommands = {
-  [key in GameContainerType]: GameCommandContainer;
+  [key in GameCommandType]: GameCommandContainer;
 };
 
 export default GameCommands;

--- a/beta-src/src/state/interfaces/OrderState.ts
+++ b/beta-src/src/state/interfaces/OrderState.ts
@@ -3,9 +3,11 @@ import OrderType from "../../types/state/OrderType";
 
 export interface OrderState {
   inProgress: boolean;
-  unitID: string;
-  onTerritory: Territory;
+  onTerritory: Territory | null;
+  orderID: string;
+  toTerritory: Territory | null;
   type?: OrderType;
+  unitID: string;
 }
 
 export default OrderState;

--- a/beta-src/src/state/interfaces/SavedOrders.ts
+++ b/beta-src/src/state/interfaces/SavedOrders.ts
@@ -1,11 +1,23 @@
+import TerritoryClass from "../../models/TerritoryClass";
+
 interface OrderMetaUpdate {
   type: string;
   toTerrID: string | null;
+  viaConvoy?: string | null;
 }
 
 interface OrderMeta {
   saved: boolean;
   update?: OrderMetaUpdate;
+  allowedBorderCrossings?: TerritoryClass[];
+}
+
+export interface EditOrderMeta {
+  [key: string]: {
+    saved?: boolean;
+    update?: OrderMetaUpdate;
+    allowedBorderCrossings?: TerritoryClass[];
+  };
 }
 
 interface OrdersMeta {

--- a/beta-src/src/types/state/GameCommandType.ts
+++ b/beta-src/src/types/state/GameCommandType.ts
@@ -1,2 +1,0 @@
-type GameCommandType = "territoryCommands" | "unitCommands";
-export default GameCommandType;

--- a/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
+++ b/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import webDiplomacyTheme from "../../webDiplomacyTheme";
+
+const WDArrowMarkerDefs = function (): React.ReactElement[] {
+  return Object.entries(webDiplomacyTheme.palette.arrowColors).map(
+    ([arrowType, config]) => (
+      <marker
+        id={`arrowHead__${arrowType}`}
+        markerWidth={8}
+        markerHeight={8}
+        refX={0}
+        refY={4}
+        orient="auto"
+      >
+        <polygon points="0 0, 8 4, 0 8" fill={config.main} />
+      </marker>
+    ),
+  );
+};
+
+export default WDArrowMarkerDefs;

--- a/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
+++ b/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
@@ -8,7 +8,7 @@ const WDArrowMarkerDefs = function (): React.ReactElement[] {
         id={`arrowHead__${arrowType}`}
         markerWidth={8}
         markerHeight={8}
-        refX={0}
+        refX={7.1}
         refY={4}
         orient="auto"
       >

--- a/beta-src/src/utils/map/addUnitToTerritory.tsx
+++ b/beta-src/src/utils/map/addUnitToTerritory.tsx
@@ -26,11 +26,12 @@ export default function addUnitToTerritory(
     unit,
     country,
   };
+  const id = `${Territory[mappedTerritory.territory]}-unit`;
   const unitIcon =
     unit.type === "Army" ? (
-      <WDArmyIcon country={country} meta={meta} />
+      <WDArmyIcon id={id} country={country} meta={meta} />
     ) : (
-      <WDFleetIcon country={country} meta={meta} />
+      <WDFleetIcon id={id} country={country} meta={meta} />
     );
   const wrappedUnit = (
     <Provider store={store}>

--- a/beta-src/src/utils/map/drawCurrentMoveOrders.ts
+++ b/beta-src/src/utils/map/drawCurrentMoveOrders.ts
@@ -1,0 +1,21 @@
+import TerritoryMap from "../../data/map/variants/classic/TerritoryMap";
+import ArrowType from "../../enums/ArrowType";
+import drawArrow from "./drawArrow";
+
+export default function drawCurrentMoveOrders(data): void {
+  const { currentOrders, territories, units } = data;
+
+  if (currentOrders && units && territories) {
+    currentOrders
+      .filter((order) => order.type === "Move")
+      .forEach(({ id, toTerrID, unitID }) => {
+        const unitData = units[unitID];
+        const onTerrDetails = territories[unitData.terrID];
+        const toTerrDetails = territories[toTerrID];
+        const fromTerr = TerritoryMap[onTerrDetails.name].territory;
+        const toTerr = TerritoryMap[toTerrDetails.name].territory;
+        const arrowIdentifier = `${id}`;
+        drawArrow(arrowIdentifier, ArrowType.MOVE, toTerr, fromTerr);
+      });
+  }
+}

--- a/beta-src/src/utils/map/getValidUnitBorderCrossings.ts
+++ b/beta-src/src/utils/map/getValidUnitBorderCrossings.ts
@@ -1,0 +1,56 @@
+import BoardClass from "../../models/BoardClass";
+import OrderClass from "../../models/OrderClass";
+import TerritoryClass from "../../models/TerritoryClass";
+import { EditOrderMeta } from "../../state/interfaces/SavedOrders";
+
+interface Props {
+  [key: string]: EditOrderMeta;
+}
+
+export default function getValidUnitBorderCrossings(data): Props {
+  const { contextVars, currentOrders, territories, territoryStatuses, units } =
+    data;
+
+  if ("contextVars" in data && contextVars.context) {
+    console.log({ contextVars });
+    const newBoard = new BoardClass(
+      JSON.parse(contextVars.context),
+      Object.values(territories),
+      territoryStatuses,
+      Object.values(units),
+    );
+
+    const newOrders: OrderClass[] = [];
+
+    currentOrders.forEach((o) => {
+      const orderUnit = newBoard.findUnitByID(o.unitID);
+      if (orderUnit) {
+        newOrders.push(new OrderClass(newBoard, o, orderUnit));
+      }
+    });
+
+    const updateOrdersMeta = {};
+    newOrders.forEach((o) => {
+      const moveChoices = o.getMoveChoices();
+      const orderUnit = newBoard.findUnitByID(o.unit.id);
+      let allowedBorderCrossings: TerritoryClass[] = [];
+      if (orderUnit) {
+        allowedBorderCrossings = moveChoices.filter((choice) => {
+          const { Borders } = choice;
+          const from = Borders.find((border) => {
+            return border.id === orderUnit.terrID;
+          });
+          if (from && orderUnit.canCrossBorder(from)) {
+            return true;
+          }
+          return false;
+        });
+        updateOrdersMeta[o.orderData.id] = {
+          allowedBorderCrossings,
+        };
+      }
+    });
+    return updateOrdersMeta;
+  }
+  return {};
+}


### PR DESCRIPTION
### Summary
This PR implements the move order for web diplomacy. This is the ability for units to move across borders to water or land territories depending on what type of unit they are and what territory they are in. Upon attempting to make an invalid move order, the cursor will display a red flash (from the mocks) indicating the move they are attempting to make is invalid. The user is able to save his/her moves by clicking the save button or ready button. This PR branches off of https://github.com/codazen/webDiplomacy/pull/75 so hold move is also testable from this PR. 

### Video
https://drive.google.com/file/d/1C2SesTorCSJkUjzgvYNnttnCxNm0pPqF/view?usp=sharing

### Testing Plan

1. Start the local development environment
2. Go to and existing / start a game.
3. Use the beta app to implement hold / move orders. 
4. Save orders by using the **save** or **ready** button.
5. Ensure that hold and move orders match between the beta and legacy application. 
