### PR TITLE
bugfix/st-petersburg-post-build

### DIFF
--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -18,7 +18,7 @@ export default function getOrdersMeta(data, phase): Props {
         updateOrdersMeta[id] = {
           saved: true,
           update: {
-            type,
+            type: toTerrID ? type : "Wait",
             toTerrID,
           },
         };


### PR DESCRIPTION
Fix an issue where the user is unable to wait/postpone if they have not previously cancelled a build.