### PR TITLE
FBFW-121 - Get Messages API - Logic Fix

### DIFF
--- a/api.php
+++ b/api.php
@@ -1032,24 +1032,6 @@ class GetMessages extends ApiEntry {
 
 		$limit = isset($limit) ? intval($limit) : $limitAmount;
 		$offset = isset($offset) ? intval($offset) : 0;
-
-		// Press Types
-		// Regular - Global and Private messaging allowed.
-		// PublicPressOnly - Only Global messaging allowed.
-		// NoPress - No messaging allowed.
-		// RulebookPress - No messaging allowed during 'Builds' and 'Retreats' phases.
-		if ($pressType == 'NoPress' || $pressType == 'RulebookPress' && $gamePhase == 'Builds' || $pressType == 'RulebookPress' && $gamePhase == 'Retreats')
-		throw new RequestException(
-			$this->JSONResponse(
-				'No messaging allowed for pressType = NoPress. No messaging allowed during "Retreats" and "Builds" phases for pressType = RulebookPress.',
-				'',
-				false,
-				[
-					'pressType' => $pressType,
-					'phase' => $gamePhase,
-				]
-			)
-		);
 		
 		if ($gameID === null || !is_numeric($gameID))
 			throw new RequestException(
@@ -1070,6 +1052,25 @@ class GetMessages extends ApiEntry {
 		// Global Get all messages addressed to everyone
 		if ($countryID == 0) {
 			$where = "toCountryID = 0";
+		}
+
+		// Press Types
+		// Regular - Global and Private messaging allowed.
+		// PublicPressOnly - Only Global messaging allowed.
+		// NoPress - No messaging allowed.
+		// RulebookPress - No messaging allowed during 'Builds' and 'Retreats' phases.
+		else if ($countryID != $toCountryID && $pressType == 'NoPress' || $countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Builds' || $countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Retreats') {
+			throw new RequestException(
+				$this->JSONResponse(
+					'No messaging allowed for pressType = NoPress. No messaging allowed during "Retreats" and "Builds" phases for pressType = RulebookPress.',
+					'',
+					false,
+					[
+						'pressType' => $pressType,
+						'phase' => $gamePhase,
+					]
+				)
+			);
 		}
 
 		// Only get messages sent between

--- a/api.php
+++ b/api.php
@@ -1059,7 +1059,10 @@ class GetMessages extends ApiEntry {
 		// PublicPressOnly - Only Global messaging allowed.
 		// NoPress - No messaging allowed.
 		// RulebookPress - No messaging allowed during 'Builds' and 'Retreats' phases.
-		else if ($countryID != $toCountryID && $pressType == 'NoPress' || $countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Builds' || $countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Retreats') {
+		else if ( 
+			($countryID != $toCountryID && $pressType == 'NoPress') || 
+			($countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Builds') || 
+			($countryID != $toCountryID && $pressType == 'RulebookPress' && $gamePhase == 'Retreats') ) {
 			throw new RequestException(
 				$this->JSONResponse(
 					'No messaging allowed for pressType = NoPress. No messaging allowed during "Retreats" and "Builds" phases for pressType = RulebookPress.',
@@ -1068,6 +1071,7 @@ class GetMessages extends ApiEntry {
 					[
 						'pressType' => $pressType,
 						'phase' => $gamePhase,
+						'test' => 'test',
 					]
 				)
 			);


### PR DESCRIPTION
- Updated logic to always return global messages
- Updated logic to show Notes (messages to yourself) during Retreat/Builds phases for NoPress Rulebook Press

## Global Messaging
http://localhost/api.php?route=game/getmessages&gameID=4&countryID=0

![Screen Shot 2022-04-27 at 3 42 53 PM](https://user-images.githubusercontent.com/1848053/165643472-ecafb102-80bd-4643-81c5-cede7f7e92b1.png)

## Notes Messaging (Messaging to yourself)
http://localhost/api.php?route=game/getmessages&gameID=4&countryID=3&toCountryID=3

Notes Messaging during Retreat/Builds phases for NoPress Rulebook Press should still be available

![Screen Shot 2022-04-27 at 3 43 26 PM](https://user-images.githubusercontent.com/1848053/165643473-d11190d6-f61a-45b9-a6c4-6d1bb196b583.png)

![Screen Shot 2022-04-27 at 3 43 03 PM](https://user-images.githubusercontent.com/1848053/165643474-df805b34-79b0-430b-b57b-970475a183fc.png)

