### PR TITLE
Add the ability for the user to execute support hold orders on own units.

### DIFF
--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -539,9 +539,7 @@ const gameApiSlice = createSlice({
           if (terrEnum === unitBeingSupported.onTerritory) {
             // attemping support hold
             const match = unitSupporting.supportHoldChoices?.find(
-              ({ unitID: uID }) => {
-                return uID === unitBeingSupported.unitID;
-              },
+              ({ unitID: uID }) => uID === unitBeingSupported.unitID,
             );
             if (match) {
               // execute support hold
@@ -565,9 +563,7 @@ const gameApiSlice = createSlice({
             );
             if (supportMoveMatch && supportMoveMatch.supportMoveFrom.length) {
               const match = supportMoveMatch.supportMoveFrom.find(
-                ({ unitID: uID }) => {
-                  return uID === unitBeingSupported.unitID;
-                },
+                ({ unitID: uID }) => uID === unitBeingSupported.unitID,
               );
               if (match) {
                 // execute support move

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -33,6 +33,7 @@ import drawSupportMoveOrders from "../../utils/map/drawSupportMoveOrders";
 import drawMoveOrders from "../../utils/map/drawMoveOrders";
 import generateMaps from "../../utils/state/generateMaps";
 import removeAllArrows from "../../utils/map/removeAllArrows";
+import drawSupportHoldOrders from "../../utils/map/drawSupportHoldOrders";
 
 export const fetchGameData = createAsyncThunk(
   ApiRoute.GAME_DATA,
@@ -316,6 +317,7 @@ const drawOrders = (state) => {
   removeAllArrows();
   drawMoveOrders(data, ordersMeta);
   drawSupportMoveOrders(data, maps, ordersMeta);
+  drawSupportHoldOrders(data, ordersMeta);
   drawBuilds(state);
 };
 
@@ -530,34 +532,58 @@ const gameApiSlice = createSlice({
         }
       } else if (inProgress && method === "dblClick") {
         if (subsequentClicks.length) {
-          // user is trying to do a support move
+          // user is trying to do a support move or a support hold
           const unitSupporting = ordersMeta[orderID];
           const unitBeingSupported = subsequentClicks[0];
           const terrEnum = Number(Territory[territoryName]);
-          const supportMoveMatch = unitSupporting.supportMoveChoices?.find(
-            ({ supportMoveTo: { name } }) =>
-              TerritoryMap[name].territory === terrEnum,
-          );
-          if (supportMoveMatch && supportMoveMatch.supportMoveFrom.length) {
-            const moveFromMatch = supportMoveMatch.supportMoveFrom.find(
+          if (terrEnum === unitBeingSupported.onTerritory) {
+            // attemping support hold
+            const match = unitSupporting.supportHoldChoices?.find(
               ({ unitID: uID }) => {
                 return uID === unitBeingSupported.unitID;
               },
             );
-            if (moveFromMatch) {
-              // execute support move
+            if (match) {
+              // execute support hold
               updateOrdersMeta(state, {
                 [orderID]: {
                   saved: false,
                   update: {
-                    type: "Support move",
-                    toTerrID: supportMoveMatch.supportMoveTo.id,
-                    fromTerrID: moveFromMatch.id,
+                    type: "Support hold",
+                    toTerrID: match.id,
                   },
                 },
               });
               resetOrder(state);
               return;
+            }
+          } else {
+            // attempting support move
+            const supportMoveMatch = unitSupporting.supportMoveChoices?.find(
+              ({ supportMoveTo: { name } }) =>
+                TerritoryMap[name].territory === terrEnum,
+            );
+            if (supportMoveMatch && supportMoveMatch.supportMoveFrom.length) {
+              const match = supportMoveMatch.supportMoveFrom.find(
+                ({ unitID: uID }) => {
+                  return uID === unitBeingSupported.unitID;
+                },
+              );
+              if (match) {
+                // execute support move
+                updateOrdersMeta(state, {
+                  [orderID]: {
+                    saved: false,
+                    update: {
+                      type: "Support move",
+                      toTerrID: supportMoveMatch.supportMoveTo.id,
+                      fromTerrID: match.id,
+                    },
+                  },
+                });
+                resetOrder(state);
+                return;
+              }
             }
           }
           const command: GameCommand = {

--- a/beta-src/src/state/interfaces/SavedOrders.ts
+++ b/beta-src/src/state/interfaces/SavedOrders.ts
@@ -17,6 +17,7 @@ interface OrderMeta {
   allowedBorderCrossings?: TerritoryClass[];
   saved: boolean;
   supportMoveChoices?: SupportMoveChoice[];
+  supportHoldChoices?: TerritoryClass[];
   update?: OrderMetaUpdate;
   originalOrder: IOrderData;
 }
@@ -28,6 +29,7 @@ export interface EditOrderMeta {
     allowedBorderCrossings?: TerritoryClass[];
     originalOrder?: IOrderData;
     supportMoveChoices?: SupportMoveChoice[];
+    suuportHoldChoices?: TerritoryClass[];
   };
 }
 

--- a/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
+++ b/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
@@ -38,7 +38,7 @@ const WDArrowMarkerColors = function (
                 id={`arrowHead__${ArrowType[arrowType]}_${ArrowColor[arrowColor]}`}
                 markerWidth={8}
                 markerHeight={8}
-                refX="2%"
+                refX="16"
                 refY={4}
                 orient="auto"
               >

--- a/beta-src/src/utils/map/drawSupportHoldOrders.ts
+++ b/beta-src/src/utils/map/drawSupportHoldOrders.ts
@@ -1,0 +1,36 @@
+import TerritoryMap from "../../data/map/variants/classic/TerritoryMap";
+import ArrowColor from "../../enums/ArrowColor";
+import ArrowType from "../../enums/ArrowType";
+import OrdersMeta from "../../state/interfaces/SavedOrders";
+import drawArrow from "./drawArrow";
+
+export default function drawSupportHoldOrders(
+  data,
+  ordersMeta: OrdersMeta,
+): void {
+  const { currentOrders, territories, units } = data;
+  const ordersMetaEntries = Object.entries(ordersMeta);
+  if (ordersMetaEntries.length && units && territories) {
+    ordersMetaEntries
+      .filter(([, { update }]) => update?.type === "Support hold")
+      .forEach(([orderID, { update }]) => {
+        const originalOrder = currentOrders.find(({ id }) => id === orderID);
+        if (originalOrder && update && update.toTerrID) {
+          const { id, unitID } = originalOrder;
+          const unitData = units[unitID];
+          const onTerrDetails = territories[unitData.terrID];
+          const toTerrDetails = territories[update.toTerrID];
+          const fromTerr = TerritoryMap[onTerrDetails.name].territory;
+          const toTerr = TerritoryMap[toTerrDetails.name].territory;
+          drawArrow(
+            id,
+            ArrowType.HOLD,
+            ArrowColor.SUPPORT_HOLD,
+            "unit",
+            toTerr,
+            fromTerr,
+          );
+        }
+      });
+  }
+}

--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -54,6 +54,7 @@ export default function getOrdersMeta(data, phase): Props {
       newOrders.forEach((o) => {
         const moveChoices = o.getMoveChoices();
         const supportMoveToChoices = o.getSupportMoveToChoices();
+        const supportHoldChoices = o.getSupportHoldChoices();
         const supportMoveChoices: SupportMoveChoice[] = [];
         supportMoveToChoices.forEach((supportMoveTo) => {
           const supportMoveFrom = o.getSupportMoveFromChoices(supportMoveTo);
@@ -82,6 +83,7 @@ export default function getOrdersMeta(data, phase): Props {
             ...updateOrdersMeta[o.orderData.id],
             allowedBorderCrossings,
             supportMoveChoices,
+            supportHoldChoices,
           };
         }
       });


### PR DESCRIPTION
### Summary
This PR adds the ability for a user to execute a support hold order on its own units. It also gets the current support hold orders from the beta app to display them on the map on initial load. The code now is able to distinguish between a support hold and support move and show correct visuals. 

A support hold is executed the following way: 
1. double clicking on the supporting unit
2. click on the unit being supported
3. click on the territory the supported unit is in

### Video
https://drive.google.com/file/d/1hwFCuz7MdfjF5w0sst0jpPZlxDv3Bhza/view?usp=sharing