### PR TITLE
Enable the user to support hold foreign units.

### DIFF
--- a/beta-src/src/components/ui/WDUnitController.tsx
+++ b/beta-src/src/components/ui/WDUnitController.tsx
@@ -52,20 +52,10 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
 
   processNextCommand(commands, commandActions);
 
-  const clickAction = (e) => {
+  const clickAction = (e, method) => {
     dispatch(
       gameApiSliceActions.processUnitClick({
-        method: "click",
-        onTerritory: meta.mappedTerritory.territory,
-        unitID: meta.unit.id,
-      }),
-    );
-  };
-
-  const doubleClickAction = (e) => {
-    dispatch(
-      gameApiSliceActions.processUnitDoubleClick({
-        method: "dblClick",
+        method,
         onTerritory: meta.mappedTerritory.territory,
         unitID: meta.unit.id,
       }),
@@ -73,7 +63,7 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
   };
 
   const handleClick = debounce((e) => {
-    clickAction(e);
+    clickAction(e, "click");
   }, 200);
 
   const handleSingleClick = (e) => {
@@ -82,7 +72,7 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
 
   const handleDoubleClick = (e) => {
     handleClick[1]();
-    doubleClickAction(e);
+    clickAction(e, "dblClick");
   };
 
   return (

--- a/beta-src/src/components/ui/WDUnitController.tsx
+++ b/beta-src/src/components/ui/WDUnitController.tsx
@@ -3,7 +3,7 @@ import { GameIconProps } from "../../interfaces/Icons";
 import UIState from "../../enums/UIState";
 import debounce from "../../utils/debounce";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
-import { gameApiSliceActions, gameData } from "../../state/game/game-api-slice";
+import { gameApiSliceActions } from "../../state/game/game-api-slice";
 import processNextCommand from "../../utils/processNextCommand";
 
 interface UnitControllerProps {
@@ -21,8 +21,6 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
   const commands = useAppSelector(
     (state) => state.game.commands.unitCommands[meta.unit.id],
   );
-
-  const { data } = useAppSelector(gameData);
 
   const deleteCommand = (key) => {
     dispatch(
@@ -54,23 +52,7 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
 
   processNextCommand(commands, commandActions);
 
-  let unitCanInitiateOrder = false;
-  if ("currentOrders" in data) {
-    const { currentOrders } = data;
-    if (currentOrders) {
-      for (let i = 0; i < currentOrders.length; i += 1) {
-        if (currentOrders[i].unitID === meta.unit.id) {
-          unitCanInitiateOrder = true;
-          break;
-        }
-      }
-    }
-  }
-
   const clickAction = (e) => {
-    if (!unitCanInitiateOrder) {
-      return;
-    }
     dispatch(
       gameApiSliceActions.processUnitClick({
         method: "click",
@@ -81,9 +63,6 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
   };
 
   const doubleClickAction = (e) => {
-    if (!unitCanInitiateOrder) {
-      return;
-    }
     dispatch(
       gameApiSliceActions.processUnitDoubleClick({
         method: "dblClick",

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -385,9 +385,10 @@ const gameApiSlice = createSlice({
       if (inProgress) {
         if (unitID === clickData.payload.unitID) {
           resetOrder(state);
-        } else if (type === "hold" && onTerritory !== null) {
-          highlightMapTerritoriesBasedOnStatuses(state);
-        } else if (type === "move" && toTerritory !== null) {
+        } else if (
+          (type === "hold" || type === "move") &&
+          onTerritory !== null
+        ) {
           highlightMapTerritoriesBasedOnStatuses(state);
         } else if (
           method === "dblClick" &&

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -344,30 +344,37 @@ const gameApiSlice = createSlice({
     },
     processUnitDoubleClick(state, clickData) {
       const {
-        order,
         data: {
           data: { contextVars },
         },
+        ownUnits,
       } = current(state);
+      if (!ownUnits.includes(clickData.payload.unitID)) {
+        return;
+      }
       if (contextVars?.context?.orderStatus) {
         const orderStates = getOrderStates(contextVars?.context?.orderStatus);
         if (orderStates.Ready) {
           return;
         }
       }
-      const { inProgress } = order;
-      if (inProgress) {
-        // double click move in progress
-      } else {
-        startNewOrder(state, clickData);
-      }
+      startNewOrder(state, clickData);
     },
     processUnitClick(state, clickData) {
       const {
-        order,
         data: {
           data: { contextVars },
         },
+        order: {
+          inProgress,
+          method,
+          onTerritory,
+          orderID,
+          toTerritory,
+          type,
+          unitID,
+        },
+        ownUnits,
       } = current(state);
       if (contextVars?.context?.orderStatus) {
         const orderStates = getOrderStates(contextVars?.context?.orderStatus);
@@ -375,32 +382,29 @@ const gameApiSlice = createSlice({
           return;
         }
       }
-      const { inProgress } = order;
       if (inProgress) {
-        if (order.type === "hold" && order.onTerritory !== null) {
+        if (unitID === clickData.payload.unitID) {
+          resetOrder(state);
+        } else if (type === "hold" && onTerritory !== null) {
           highlightMapTerritoriesBasedOnStatuses(state);
-        } else if (order.type === "move" && order.toTerritory !== null) {
+        } else if (type === "move" && toTerritory !== null) {
           highlightMapTerritoriesBasedOnStatuses(state);
         } else if (
-          order.method === "dblClick" &&
-          order.unitID !== clickData.payload.unitID
+          method === "dblClick" &&
+          unitID !== clickData.payload.unitID
         ) {
           state.order.subsequentClicks.push({
             ...{
               inProgress: true,
-              orderID: order.orderID,
+              orderID,
               toTerritory: null,
             },
             ...clickData.payload,
           });
-          return;
+        } else if (ownUnits.includes(clickData.payload.unitID)) {
+          startNewOrder(state, clickData);
         }
-      }
-      if (inProgress && order.unitID === clickData.payload.unitID) {
-        resetOrder(state);
-      } else if (inProgress && order.unitID !== clickData.payload.unitID) {
-        startNewOrder(state, clickData);
-      } else {
+      } else if (ownUnits.includes(clickData.payload.unitID)) {
         startNewOrder(state, clickData);
       }
     },
@@ -771,6 +775,9 @@ const gameApiSlice = createSlice({
           overview: { members, phase },
         } = current(state);
         state.maps = generateMaps(data);
+        data.currentOrders?.forEach(({ unitID }) => {
+          state.ownUnits.push(unitID);
+        });
         const unitsToDraw = getUnits(data, members);
         unitsToDraw.forEach(({ country, mappedTerritory, unit }) => {
           const command: GameCommand = {

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -24,6 +24,7 @@ const initialState: GameState = {
     unitID: "",
   },
   ordersMeta: {},
+  ownUnits: [],
   maps: {
     territoryToUnit: {},
     unitToOrder: {},

--- a/beta-src/src/state/interfaces/GameState.ts
+++ b/beta-src/src/state/interfaces/GameState.ts
@@ -18,6 +18,7 @@ export interface GameState {
   overview: GameOverviewResponse;
   order: OrderState;
   ordersMeta: OrdersMeta;
+  ownUnits: string[];
   territoriesMeta: TerritoriesMeta;
   commands: GameCommands;
   status: GameStatusResponse;


### PR DESCRIPTION
### Summary
This PR enables users to support hold a foreign unit. 

To support hold a foreign unit the user must do the following:
1. double click the supporting unit
2. single click the foreign unit being supported
3. single click the territory the foreign unit is on

### Video
https://drive.google.com/file/d/1XUCNQGrxfFf5KfprwJaGfSVu6Pa4EJ5V/view?usp=sharing