### PR TITLE
feature/fbfw-129-convoy-implied

### DIFF
--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -31,6 +31,7 @@ const initialState: GameState = {
     unitToOrder: {},
     unitToTerritory: {},
     enumToTerritory: {},
+    territoryToEnum: {},
   },
   territoriesMeta: {},
   commands: {

--- a/beta-src/src/state/interfaces/GameStateMaps.ts
+++ b/beta-src/src/state/interfaces/GameStateMaps.ts
@@ -5,4 +5,5 @@ export default interface GameStateMaps {
   unitToOrder: GameStateMap;
   unitToTerritory: GameStateMap;
   enumToTerritory: GameStateMap;
+  territoryToEnum: GameStateMap;
 }

--- a/beta-src/src/utils/map/drawConvoyOrders.ts
+++ b/beta-src/src/utils/map/drawConvoyOrders.ts
@@ -26,19 +26,38 @@ export default function drawConvoyOrders(
             const unitBeingConvoyed = maps.territoryToUnit[fromTerrID];
             const unitBeingConvoyedOrder = maps.unitToOrder[unitBeingConvoyed];
 
-            const supportingTerritory = maps.unitToTerritory[unitID];
-            const supportingTerritoryDetails = territories[supportingTerritory];
+            const convoyingTerritory = maps.unitToTerritory[unitID];
+            const convoyingTerritoryDetails = territories[convoyingTerritory];
 
-            const { update: unitBeingSupportedOrderDetails } =
+            const { update: unitBeingConvoyedOrderDetails } =
               ordersMeta[unitBeingConvoyedOrder];
-            if (unitBeingSupportedOrderDetails) {
+
+            if (update.toTerrID === unitBeingConvoyedOrderDetails?.toTerrID) {
               drawArrow(
                 id,
                 ArrowType.CONVOY,
                 ArrowColor.CONVOY,
                 "arrow",
                 unitBeingConvoyedOrder,
-                TerritoryMap[supportingTerritoryDetails.name].territory,
+                TerritoryMap[convoyingTerritoryDetails.name].territory,
+              );
+            } else {
+              // draw implied arrows
+              drawArrow(
+                `${id}-implied`,
+                ArrowType.MOVE,
+                ArrowColor.IMPLIED,
+                "territory",
+                Number(maps.territoryToEnum[toTerrID]),
+                Number(maps.territoryToEnum[fromTerrID]),
+              );
+              drawArrow(
+                id,
+                ArrowType.CONVOY,
+                ArrowColor.CONVOY,
+                "arrow",
+                `${id}-implied`,
+                TerritoryMap[convoyingTerritoryDetails.name].territory,
               );
             }
           }

--- a/beta-src/src/utils/map/drawMoveOrders.ts
+++ b/beta-src/src/utils/map/drawMoveOrders.ts
@@ -1,32 +1,82 @@
 import TerritoryMap from "../../data/map/variants/classic/TerritoryMap";
 import ArrowColor from "../../enums/ArrowColor";
 import ArrowType from "../../enums/ArrowType";
+import { GameState } from "../../state/interfaces/GameState";
 import OrdersMeta from "../../state/interfaces/SavedOrders";
 import drawArrow from "./drawArrow";
 
-export default function drawMoveOrders(data, ordersMeta: OrdersMeta): void {
+export default function drawMoveOrders(
+  data: GameState["data"]["data"],
+  maps: GameState["maps"],
+  ordersMeta: OrdersMeta,
+  board: GameState["board"],
+): void {
   const { currentOrders, territories, units } = data;
   const ordersMetaEntries = Object.entries(ordersMeta);
   if (ordersMetaEntries.length && units && territories) {
     ordersMetaEntries
       .filter(([, { update }]) => update?.type === "Move")
       .forEach(([orderID, { update }]) => {
-        const originalOrder = currentOrders.find(({ id }) => id === orderID);
-        if (originalOrder && update && update.toTerrID) {
-          const { id, unitID } = originalOrder;
-          const unitData = units[unitID];
-          const onTerrDetails = territories[unitData.terrID];
-          const toTerrDetails = territories[update.toTerrID];
-          const fromTerr = TerritoryMap[onTerrDetails.name].territory;
-          const toTerr = TerritoryMap[toTerrDetails.name].territory;
-          drawArrow(
-            id,
-            ArrowType.MOVE,
-            ArrowColor.MOVE,
-            "territory",
-            toTerr,
-            fromTerr,
-          );
+        const originalOrder = currentOrders?.find(({ id }) => id === orderID);
+        if (originalOrder && update) {
+          const { convoyPath, toTerrID, viaConvoy } = update;
+          if (toTerrID) {
+            const { id, unitID } = originalOrder;
+            const unitData = units[unitID];
+            const onTerrDetails = territories[unitData.terrID];
+            const toTerrDetails = territories[toTerrID];
+            const fromTerr = TerritoryMap[onTerrDetails.name].territory;
+            const toTerr = TerritoryMap[toTerrDetails.name].territory;
+            drawArrow(
+              id,
+              ArrowType.MOVE,
+              ArrowColor.MOVE,
+              "territory",
+              toTerr,
+              fromTerr,
+            );
+            if (viaConvoy === "Yes" && board) {
+              // implied convoy arrow
+              let path = convoyPath;
+              if (!convoyPath) {
+                const onTerritory = board.findTerritoryByID(unitData.terrID);
+                path = board
+                  .findUnitByID(unitID)
+                  ?.ConvoyGroup.pathArmyToCoastWithoutFleet(
+                    onTerritory,
+                    board.findTerritoryByID(toTerrID),
+                    onTerritory,
+                  );
+              }
+              if (path) {
+                path
+                  .filter((p) => p !== unitData.terrID)
+                  .forEach((p) => {
+                    const convoyingUnitID = maps.territoryToUnit[p];
+                    const convoyingUnitOrder =
+                      maps.unitToOrder[convoyingUnitID];
+                    const unitOrderMeta = ordersMeta[convoyingUnitOrder].update;
+                    if (
+                      unitOrderMeta?.fromTerrID !== unitData.terrID ||
+                      unitOrderMeta?.toTerrID !== update.toTerrID
+                    ) {
+                      drawArrow(
+                        `${id}-implied`,
+                        ArrowType.CONVOY,
+                        ArrowColor.IMPLIED,
+                        "arrow",
+                        id,
+                        Number(
+                          maps.territoryToEnum[
+                            maps.unitToTerritory[convoyingUnitID]
+                          ],
+                        ),
+                      );
+                    }
+                  });
+              }
+            }
+          }
         }
       });
   }

--- a/beta-src/src/utils/map/drawOrders.ts
+++ b/beta-src/src/utils/map/drawOrders.ts
@@ -8,12 +8,13 @@ import removeAllArrows from "./removeAllArrows";
 
 export default function drawOrders(state): void {
   const {
+    board,
     data: { data },
     maps,
     ordersMeta,
   } = current(state);
   removeAllArrows();
-  drawMoveOrders(data, ordersMeta);
+  drawMoveOrders(data, maps, ordersMeta, board);
   drawSupportMoveOrders(data, maps, ordersMeta);
   drawSupportHoldOrders(data, ordersMeta);
   drawConvoyOrders(data, maps, ordersMeta);

--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -38,7 +38,7 @@ export default function getOrdersMeta(
       }
 
       currentOrders?.forEach((o) => {
-        const { id, unitID, type, toTerrID, fromTerrID } = o;
+        const { id, unitID, type, toTerrID, fromTerrID, viaConvoy } = o;
         const orderUnit = board.findUnitByID(unitID);
         if (orderUnit) {
           newOrders.push(new OrderClass(board, o, orderUnit));
@@ -47,6 +47,7 @@ export default function getOrdersMeta(
               type,
               toTerrID,
               fromTerrID,
+              viaConvoy,
             },
           };
         }

--- a/beta-src/src/utils/state/generateMaps.ts
+++ b/beta-src/src/utils/state/generateMaps.ts
@@ -10,6 +10,7 @@ export default function generateMaps(
   const unitToOrder: GameStateMaps["unitToOrder"] = {};
   const unitToTerritory: GameStateMaps["unitToTerritory"] = {};
   const enumToTerritory: GameStateMaps["enumToTerritory"] = {};
+  const territoryToEnum: GameStateMaps["territoryToEnum"] = {};
 
   Object.values(units).forEach(({ id, terrID }) => {
     territoryToUnit[terrID] = id;
@@ -18,6 +19,7 @@ export default function generateMaps(
 
   Object.values(territories).forEach(({ id, name }) => {
     enumToTerritory[TerritoryMap[name].territory] = id;
+    territoryToEnum[id] = TerritoryMap[name].territory.toString();
   });
 
   currentOrders?.forEach(({ id, unitID }) => {
@@ -29,5 +31,6 @@ export default function generateMaps(
     unitToOrder,
     unitToTerritory,
     enumToTerritory,
+    territoryToEnum,
   };
 }


### PR DESCRIPTION
### Summary
This PR adds the implied arrow when the user changes the order for the unit being convoyed. For example, if a user were to change the order of the unit being convoyed after a convoy order has been set then this will draw the necessary implied arrows to tell the user that some of the fleets are still making convoy orders. 

This PR covers scenario 2 "Redirected Convoy Move (Unsuccessful)"  from the task: https://codazen.atlassian.net/browse/FBFW-129

### Video
https://drive.google.com/file/d/1oZ89CxbDIoO_R2HsDXOCgB8fldduuh6o/view?usp=sharing