### PR TITLE
bugfix/-infinite-re-renders-on-no-orders

### DIFF
--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -4,7 +4,7 @@ import { Box, IconButton, Link, useTheme } from "@mui/material";
 import WDPositionContainer from "./WDPositionContainer";
 import Position from "../../enums/Position";
 import { useAppSelector } from "../../state/hooks";
-import { gameData, gameOverview } from "../../state/game/game-api-slice";
+import { gameOverview } from "../../state/game/game-api-slice";
 import { CountryTableData } from "../../interfaces";
 import Country from "../../enums/Country";
 import WDFullModal from "./WDFullModal";
@@ -19,7 +19,6 @@ import WDMoveControls from "./WDMoveControls";
 import MoveStatus from "../../types/MoveStatus";
 import countryMap from "../../data/map/variants/classic/CountryMap";
 import WDHomeIcon from "./icons/WDHomeIcon";
-import getOrderStates from "../../utils/state/getOrderStates";
 
 const abbrMap = {
   Russia: "RUS",
@@ -60,8 +59,8 @@ const WDUI: React.FC = function (): React.ReactElement {
   } = useAppSelector(gameOverview);
 
   const {
-    data: { contextVars },
-  } = useAppSelector(gameData);
+    member: { orderStatus },
+  } = user;
 
   const constructTableData = (member) => {
     const memberCountry: Country = countryMap[member.country];
@@ -123,26 +122,18 @@ const WDUI: React.FC = function (): React.ReactElement {
     }
   }, [popoverTrigger]);
 
-  if (contextVars?.context?.orderStatus) {
-    const orderStates = getOrderStates(contextVars.context.orderStatus);
-    if (orderStates.None) {
-      setReadyDisabled(true);
-    }
-    if (!orderStates.Ready && gameState.ready) {
-      setGameState((preState) => ({
-        ...preState,
-        [Move.READY]: false,
-      }));
-    }
-    if ((orderStates.Ready || orderStates.None) && !gameState.ready) {
-      setGameState((preState) => ({
-        ...preState,
-        [Move.READY]: true,
-      }));
-    }
-  } else if (gameState.ready) {
-    toggleState(Move.READY);
+  if (orderStatus.None && !readyDisabled) {
+    setReadyDisabled(true);
   }
+
+  React.useEffect(() => {
+    if (orderStatus.Ready !== gameState.ready) {
+      setGameState((preState) => ({
+        ...preState,
+        [Move.READY]: orderStatus.Ready,
+      }));
+    }
+  }, [orderStatus]);
 
   const popover = popoverTrigger.current ? (
     <WDPopover

--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -20,7 +20,7 @@ export default function getOrdersMeta(
   const { contextVars, currentOrders, territories, units } = data;
 
   const updateOrdersMeta = {};
-  if (contextVars?.context) {
+  if (contextVars?.context && currentOrders?.length) {
     if (phase === "Builds") {
       currentOrders?.forEach(({ id, toTerrID, type }) => {
         updateOrdersMeta[id] = {
@@ -38,7 +38,7 @@ export default function getOrdersMeta(
         return updateOrdersMeta;
       }
 
-      currentOrders?.forEach((o) => {
+      currentOrders.forEach((o) => {
         const { id, unitID, type, toTerrID, fromTerrID, viaConvoy } = o;
         let orderUnit = board.findUnitByID(unitID);
         if (!orderUnit && phase === "Retreats") {

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -1,5 +1,6 @@
 import SavedOrdersConfirmation from "../../../../../interfaces/state/SavedOrdersConfirmation";
 import updateUnitsRetreat from "../../../../map/updateUnitsRetreat";
+import getOrderStates from "../../../getOrderStates";
 
 /* eslint-disable no-param-reassign */
 export default function saveOrdersFulfilled(state, action): void {
@@ -10,6 +11,13 @@ export default function saveOrdersFulfilled(state, action): void {
       state.data.data.contextVars = {
         context: newContext,
         contextKey: newContextKey,
+      };
+      const orderStates = getOrderStates(newContext.orderStatus);
+      state.overview.user.member.orderStatus = {
+        Completed: orderStates.Completed,
+        Ready: orderStates.Ready,
+        None: orderStates.None,
+        Saved: orderStates.Saved,
       };
     }
 

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -7,7 +7,6 @@ import GameDataResponse from "../../../../state/interfaces/GameDataResponse";
 import { GameState } from "../../../../state/interfaces/GameState";
 import { UnitSlotNames } from "../../../../types/map/UnitSlotName";
 import highlightMapTerritoriesBasedOnStatuses from "../../../map/highlightMapTerritoriesBasedOnStatuses";
-import getOrderStates from "../../getOrderStates";
 import processConvoy from "../../processConvoy";
 import resetOrder from "../../resetOrder";
 import setCommand from "../../setCommand";
@@ -43,12 +42,10 @@ export default function processMapClick(state, clickData) {
     user: { member },
     phase,
   } = overview;
-  const { currentOrders, contextVars } = data;
-  if (contextVars?.context?.orderStatus) {
-    const orderStates = getOrderStates(contextVars?.context?.orderStatus);
-    if (orderStates.Ready) {
-      return;
-    }
+  const { currentOrders } = data;
+  const { orderStatus } = member;
+  if (orderStatus.Ready) {
+    return;
   }
   const {
     payload: { clickObject, evt, name: territoryName },

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
@@ -6,7 +6,6 @@ import OrderState from "../../../../state/interfaces/OrderState";
 import OrdersMeta from "../../../../state/interfaces/SavedOrders";
 import highlightMapTerritoriesBasedOnStatuses from "../../../map/highlightMapTerritoriesBasedOnStatuses";
 import getAvailableOrder from "../../getAvailableOrder";
-import getOrderStates from "../../getOrderStates";
 import resetOrder from "../../resetOrder";
 import startNewOrder from "../../startNewOrder";
 import updateOrdersMeta from "../../updateOrdersMeta";
@@ -29,15 +28,17 @@ export default function processUnitClick(state, clickData) {
     overview: GameOverviewResponse;
   } = current(state);
   const {
-    data: { currentOrders, contextVars, units },
+    data: { currentOrders, units },
   } = data;
   const { inProgress, method, onTerritory, orderID, type, unitID } = order;
-  const { phase } = overview;
-  if (contextVars?.context?.orderStatus) {
-    const orderStates = getOrderStates(contextVars?.context?.orderStatus);
-    if (orderStates.Ready) {
-      return;
-    }
+  const {
+    phase,
+    user: {
+      member: { orderStatus },
+    },
+  } = overview;
+  if (orderStatus.Ready) {
+    return;
   }
   // Destroy Units
   const isDestroy =

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processUnitDoubleClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processUnitDoubleClick.ts
@@ -10,10 +10,7 @@ export default function processUnitDoubleClick(state, clickData): void {
     },
     ownUnits,
   } = current(state);
-  if (!ownUnits.includes(clickData.payload.unitID)) {
-    return;
-  }
-  if (orderStatus.Ready) {
+  if (orderStatus.Ready || !ownUnits.includes(clickData.payload.unitID)) {
     return;
   }
   startNewOrder(state, clickData);

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processUnitDoubleClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processUnitDoubleClick.ts
@@ -1,22 +1,20 @@
 import { current } from "@reduxjs/toolkit";
-import getOrderStates from "../../getOrderStates";
 import startNewOrder from "../../startNewOrder";
 
 export default function processUnitDoubleClick(state, clickData): void {
   const {
-    data: {
-      data: { contextVars },
+    overview: {
+      user: {
+        member: { orderStatus },
+      },
     },
     ownUnits,
   } = current(state);
   if (!ownUnits.includes(clickData.payload.unitID)) {
     return;
   }
-  if (contextVars?.context?.orderStatus) {
-    const orderStates = getOrderStates(contextVars?.context?.orderStatus);
-    if (orderStates.Ready) {
-      return;
-    }
+  if (orderStatus.Ready) {
+    return;
   }
   startNewOrder(state, clickData);
 }

--- a/beta-src/src/utils/state/updateOrdersMeta.ts
+++ b/beta-src/src/utils/state/updateOrdersMeta.ts
@@ -3,11 +3,14 @@ import drawOrders from "../map/drawOrders";
 
 /* eslint-disable no-param-reassign */
 export default function updateOrdersMeta(state, updates: EditOrderMeta): void {
-  Object.entries(updates).forEach(([orderID, update]) => {
-    state.ordersMeta[orderID] = {
-      ...state.ordersMeta[orderID],
-      ...update,
-    };
-  });
-  drawOrders(state);
+  const entries = Object.entries(updates);
+  if (entries.length) {
+    entries.forEach(([orderID, update]) => {
+      state.ordersMeta[orderID] = {
+        ...state.ordersMeta[orderID],
+        ...update,
+      };
+    });
+    drawOrders(state);
+  }
 }


### PR DESCRIPTION
Bugfix for infinite re-renders when there are no orders. Update codebase to utilize overview user order status data.