### PR TITLE
update/move-controls

### DIFF
--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { Stack, useTheme } from "@mui/material";
 import WDButton from "./WDButton";
-import MoveStatus from "../../types/MoveStatus";
 import Move from "../../enums/Move";
 import useViewport from "../../hooks/useViewport";
 import getDevice from "../../utils/getDevice";
@@ -11,25 +10,48 @@ import {
   gameApiSliceActions,
   gameData,
   gameOrdersMeta,
+  gameOverview,
   saveOrders,
 } from "../../state/game/game-api-slice";
 import UpdateOrder from "../../interfaces/state/UpdateOrder";
+import MoveStatus from "../../types/MoveStatus";
 
-interface WDMoveControlsProps {
-  gameState: MoveStatus;
-  readyDisabled: boolean;
-  toggleState: (move: Move) => void;
-}
-
-const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
-  gameState: { ready, save },
-  readyDisabled,
-  toggleState,
-}): React.ReactElement {
+const WDMoveControls: React.FC = function (): React.ReactElement {
   const theme = useTheme();
   const [viewport] = useViewport();
   const { data } = useAppSelector(gameData);
   const ordersMeta = useAppSelector(gameOrdersMeta);
+  const [readyDisabled, setReadyDisabled] = React.useState(false);
+  const [gameState, setGameState] = React.useState<MoveStatus>({
+    save: false,
+    ready: false,
+  });
+  const {
+    user: {
+      member: { orderStatus },
+    },
+  } = useAppSelector(gameOverview);
+
+  if (orderStatus.None && !readyDisabled) {
+    setReadyDisabled(true);
+  }
+
+  React.useEffect(() => {
+    if (orderStatus.Ready !== gameState.ready) {
+      setGameState((preState) => ({
+        ...preState,
+        [Move.READY]: orderStatus.Ready,
+      }));
+    }
+  }, [orderStatus]);
+
+  const toggleState = (move: Move) => {
+    setGameState((preState) => ({
+      ...preState,
+      [move]: !gameState[move],
+    }));
+  };
+
   const dispatch = useAppDispatch();
   const device = getDevice(viewport);
   let isMobile: boolean;
@@ -83,7 +105,7 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
           queryParams: {},
         };
         if (type === Move.READY) {
-          orderSubmission.queryParams = ready
+          orderSubmission.queryParams = gameState.ready
             ? { notready: "on" }
             : { ready: "on" };
         }
@@ -103,13 +125,13 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
   );
 
   if (
-    (ordersLength === ordersSaved && save) ||
-    (ordersLength !== ordersSaved && !save)
+    (ordersLength === ordersSaved && gameState.save) ||
+    (ordersLength !== ordersSaved && !gameState.save)
   ) {
     toggleState(Move.SAVE);
   }
 
-  const saveDisabled = ready || !save;
+  const saveDisabled = gameState.ready || !gameState.save;
 
   return (
     <Stack
@@ -139,7 +161,7 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
             : theme.palette.svg.filters.dropShadows[0],
         }}
       >
-        {ready ? "Unready" : "Ready"}
+        {gameState.ready ? "Unready" : "Ready"}
       </WDButton>
     </Stack>
   );

--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -14,9 +14,7 @@ import WDPhaseUI from "./WDPhaseUI";
 import UIState from "../../enums/UIState";
 import capitalizeString from "../../utils/capitalizeString";
 import Vote from "../../enums/Vote";
-import Move from "../../enums/Move";
 import WDMoveControls from "./WDMoveControls";
-import MoveStatus from "../../types/MoveStatus";
 import countryMap from "../../data/map/variants/classic/CountryMap";
 import WDHomeIcon from "./icons/WDHomeIcon";
 
@@ -29,20 +27,11 @@ const abbrMap = {
   France: "FRA",
   Turkey: "TUR",
 };
-/**
- * the game status data created here is for displaying purpose
- * the real gamestatus data will be provided from Redux Store?
- */
-const gameStatusData: MoveStatus = {
-  save: false,
-  ready: false,
-};
 
 const WDUI: React.FC = function (): React.ReactElement {
   const theme = useTheme();
 
   const [showControlModal, setShowControlModal] = React.useState(false);
-  const [readyDisabled, setReadyDisabled] = React.useState(false);
   const popoverTrigger = React.useRef<HTMLElement>(null);
 
   const {
@@ -57,10 +46,6 @@ const WDUI: React.FC = function (): React.ReactElement {
     user,
     year,
   } = useAppSelector(gameOverview);
-
-  const {
-    member: { orderStatus },
-  } = user;
 
   const constructTableData = (member) => {
     const memberCountry: Country = countryMap[member.country];
@@ -106,14 +91,6 @@ const WDUI: React.FC = function (): React.ReactElement {
     </IconButton>
   );
 
-  const [gameState, setGameState] = React.useState(gameStatusData);
-  const toggleState = (move: Move) => {
-    setGameState((preState) => ({
-      ...preState,
-      [move]: !gameState[move],
-    }));
-  };
-
   const checkIfTriggerVisible = (i = 0) => {
     if (i > 10) {
       return;
@@ -133,19 +110,6 @@ const WDUI: React.FC = function (): React.ReactElement {
   React.useEffect(() => {
     checkIfTriggerVisible();
   }, [popoverTrigger]);
-
-  if (orderStatus.None && !readyDisabled) {
-    setReadyDisabled(true);
-  }
-
-  React.useEffect(() => {
-    if (orderStatus.Ready !== gameState.ready) {
-      setGameState((preState) => ({
-        ...preState,
-        [Move.READY]: orderStatus.Ready,
-      }));
-    }
-  }, [orderStatus]);
 
   const popover = popoverTrigger.current ? (
     <WDPopover
@@ -190,11 +154,7 @@ const WDUI: React.FC = function (): React.ReactElement {
         <WDPhaseUI />
       </WDPositionContainer>
       <WDPositionContainer position={Position.BOTTOM_RIGHT}>
-        <WDMoveControls
-          readyDisabled={readyDisabled}
-          gameState={gameState}
-          toggleState={toggleState}
-        />
+        <WDMoveControls />
       </WDPositionContainer>
     </>
   );


### PR DESCRIPTION
Update move controls so that react doesn't throw a warning. It doesn't like that the child is changing state in the parent.