### PR TITLE
update/fbfw-141-add-final-call-to-polling

### DIFF
--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -11,7 +11,7 @@ import GameOverviewResponse from "../interfaces/GameOverviewResponse";
 import GameCommands from "../interfaces/GameCommands";
 import { ApiStatus, GameState } from "../interfaces/GameState";
 import GameStatusResponse from "../interfaces/GameStatusResponse";
-import GameMessages, { GameMessage } from "../interfaces/GameMessages";
+import GameMessages from "../interfaces/GameMessages";
 import { RootState } from "../store";
 import initialState from "./initial-state";
 import OrdersMeta from "../interfaces/SavedOrders";
@@ -32,6 +32,7 @@ import fetchGameDataFulfilled from "../../utils/state/gameApiSlice/extraReducers
 import updateUserActivity from "../../utils/state/gameApiSlice/reducers/updateUserActivity";
 import fetchGameOverviewFulfilled from "../../utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled";
 import saveOrdersFulfilled from "../../utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled";
+import getCurrentUnixTimestamp from "../../utils/getCurrentUnixTimestamp";
 
 export const fetchGameData = createAsyncThunk(
   ApiRoute.GAME_DATA,
@@ -220,6 +221,7 @@ const gameApiSlice = createSlice({
       .addCase(fetchGameOverview.pending, (state) => {
         state.apiStatus = "loading";
         state.activity.makeNewCall = false;
+        state.activity.lastCall = getCurrentUnixTimestamp();
       })
       .addCase(fetchGameOverview.fulfilled, fetchGameOverviewFulfilled)
       .addCase(fetchGameOverview.rejected, (state, action) => {

--- a/beta-src/src/utils/getCurrentUnixTimestamp.ts
+++ b/beta-src/src/utils/getCurrentUnixTimestamp.ts
@@ -1,0 +1,4 @@
+export default function getCurrentUnixTimestamp(): number {
+  // eslint-disable-next-line no-bitwise
+  return (Date.now() / 1000) | 0;
+}

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled.ts
@@ -1,3 +1,4 @@
+import getCurrentUnixTimestamp from "../../../../getCurrentUnixTimestamp";
 import memberActivityFrequencyMultiplier from "../../../memberActivityFrequencyMultiplier";
 
 /* eslint-disable no-param-reassign */
@@ -15,8 +16,7 @@ export default function fetchGameOverviewFulfilled(state, action): void {
   } = action.payload;
   if (processTime) {
     const membersPlaying = members.filter(({ status }) => status === "Playing");
-    // eslint-disable-next-line no-bitwise
-    const now = (Date.now() / 1000) | 0;
+    const now = getCurrentUnixTimestamp();
     const tenMinutes = 600;
     const twoMinutes = 120;
     let frequency = twoMinutes;

--- a/beta-src/src/utils/state/gameApiSlice/reducers/updateUserActivity.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/updateUserActivity.ts
@@ -18,7 +18,6 @@ export default function updateUserActivity(state, action): void {
     state.activity.processTime = newProcessTime;
   }
   if (lastActive >= lastCall + frequency) {
-    state.activity.lastCall = lastActive;
     state.activity.makeNewCall = true;
   } else {
     state.activity.makeNewCall = false;


### PR DESCRIPTION
Updates to polling to do a final poll 10 seconds after user activity has ceased. Currently polling is based on the `frequency` property in `game -> activity`. Once a user has ceased activity, it will poll again one final time 10 seconds after the last activity was registered. 

https://drive.google.com/file/d/1lAK7BcbLk-3C2fVYt3d-rUI47grZaj9J/view?usp=sharing

Relevant task: https://codazen.atlassian.net/browse/FBFW-141