### PR TITLE
fixed bug

### DIFF
--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -21,7 +21,7 @@ export default function getUnits(
   const unitsToDraw: Unit[] = [];
   const { territories, territoryStatuses, units } = data;
   Object.values(units).forEach((unit) => {
-    let territory = territories[unit.terrID];
+    const territory = territories[unit.terrID];
     const territoryStatus = territoryStatuses.find((t) => unit.terrID === t.id);
     const territoryHasMultipleUnits = Object.values(units).filter(
       (u) => u.terrID === unit.terrID,
@@ -32,16 +32,6 @@ export default function getUnits(
         )
       : undefined;
 
-    if (
-      territoryStatus?.occupiedFromTerrID &&
-      unit.id === territoryStatus.unitID &&
-      occupiedTerritory?.ownerCountryID === unit.countryID &&
-      territoryHasMultipleUnits.length > 1 &&
-      phase === "Retreats"
-    ) {
-      territory = territories[territoryStatus.occupiedFromTerrID];
-    }
-
     if (territory) {
       const mappedTerritory = TerritoryMap[territory.name];
       if (mappedTerritory) {
@@ -50,11 +40,23 @@ export default function getUnits(
         );
         if (memberCountry) {
           const { country } = memberCountry;
-          unitsToDraw.push({
-            country: countryMap[country],
-            mappedTerritory,
-            unit,
-          });
+          if (
+            (territoryStatus?.occupiedFromTerrID &&
+              unit.id !== territoryStatus.unitID &&
+              occupiedTerritory?.ownerCountryID !== unit.countryID &&
+              territoryHasMultipleUnits.length > 1 &&
+              phase === "Retreats") ||
+            (phase === "Retreats" &&
+              !territoryStatus?.occupiedFromTerrID &&
+              territoryHasMultipleUnits.length === 1) ||
+            phase !== "Retreats"
+          ) {
+            unitsToDraw.push({
+              country: countryMap[country],
+              mappedTerritory,
+              unit,
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
This PR addresses units being drawn over eachother in retreats phase. Attacker does not get drawn until after retreats phase ends
<img width="1920" alt="Screen Shot 2022-05-24 at 6 05 17 PM" src="https://user-images.githubusercontent.com/95884853/170158702-9800e686-1b8e-4490-8c83-642b9c4419f2.png">
<img width="1920" alt="Screen Shot 2022-05-24 at 6 06 05 PM" src="https://user-images.githubusercontent.com/95884853/170158715-5f1cba03-a487-4527-899c-14da813ebdb5.png">
