### PR TITLE
Hotfix for non attacking units not drawing in retreats

### DIFF
--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -46,9 +46,7 @@ export default function getUnits(
               occupiedTerritory?.ownerCountryID !== unit.countryID &&
               territoryHasMultipleUnits.length > 1 &&
               phase === "Retreats") ||
-            (phase === "Retreats" &&
-              !territoryStatus?.occupiedFromTerrID &&
-              territoryHasMultipleUnits.length === 1) ||
+            (phase === "Retreats" && territoryHasMultipleUnits.length === 1) ||
             phase !== "Retreats"
           ) {
             unitsToDraw.push({


### PR DESCRIPTION
if a unit moved to an empty terr before retreats phase it will be drawn