### PR TITLE
Bug Fix - #13 and #14

### DIFF
--- a/beta-src/src/models/BoardClass.ts
+++ b/beta-src/src/models/BoardClass.ts
@@ -157,8 +157,12 @@ export default class BoardClass {
    * @returns {TerritoryClass}
    */
   getMovableTerritories(unit: UnitClass): TerritoryClass[] {
-    return unit.Territory.CoastalBorders.reduce(
-      (acc: TerritoryClass[], cur) => {
+    const territories = this.territories.find(
+      (terr) => terr.id === unit.terrID,
+    );
+
+    if (territories) {
+      return territories.CoastalBorders.reduce((acc: TerritoryClass[], cur) => {
         if (unit.canCrossBorder(cur)) {
           const borderTerritory = this.territories.find(
             (territory) => territory.id === cur.id,
@@ -168,9 +172,9 @@ export default class BoardClass {
         }
 
         return acc;
-      },
-      [],
-    );
+      }, []);
+    }
+    return [];
   }
 
   /**

--- a/beta-src/src/utils/map/drawArrow.ts
+++ b/beta-src/src/utils/map/drawArrow.ts
@@ -22,8 +22,12 @@ export default function drawArrow(
   let x2;
   let y1;
   let y2;
-
-  const fromTerritoryName = Territory[unitTerritory];
+  let fromTerritoryName = Territory[unitTerritory];
+  // This is to find the unit on the main territory
+  // since the unit for coast are not actaully on the coastal territores
+  fromTerritoryName = fromTerritoryName
+    .replace("_NORTH_COAST", "")
+    .replace("_SOUTH_COAST", "");
   const fromTerritoryEl: SVGSVGElement = d3
     .select(`#${fromTerritoryName}-territory`)
     .node();

--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -88,11 +88,18 @@ export default function getOrdersMeta(
         let allowedBorderCrossings: TerritoryClass[] = [];
         if (orderUnit) {
           allowedBorderCrossings = moveChoices.filter((choice) => {
-            const { Borders } = choice;
+            const { Borders, CoastalBorders } = choice;
             const from = Borders.find(
               (border) => border.id === orderUnit?.terrID,
             );
-            if (from && orderUnit?.canCrossBorder(from)) {
+            const coast = CoastalBorders.find(
+              (border) => border.id === orderUnit?.terrID,
+            );
+
+            if (
+              (from && orderUnit?.canCrossBorder(from)) ||
+              (coast && orderUnit?.canCrossBorder(coast))
+            ) {
               return true;
             }
             return false;

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
@@ -135,6 +135,7 @@ export default function processUnitClick(state, clickData) {
   } else if (inProgress) {
     if (unitID === clickData.payload.unitID) {
       resetOrder(state);
+      highlightMapTerritoriesBasedOnStatuses(state);
       if (type === "disband" || type === "retreat") {
         highlightMapTerritoriesBasedOnStatuses(state);
       }

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processUnitClick.ts
@@ -136,9 +136,6 @@ export default function processUnitClick(state, clickData) {
     if (unitID === clickData.payload.unitID) {
       resetOrder(state);
       highlightMapTerritoriesBasedOnStatuses(state);
-      if (type === "disband" || type === "retreat") {
-        highlightMapTerritoriesBasedOnStatuses(state);
-      }
     } else if ((type === "hold" || type === "move") && onTerritory !== null) {
       highlightMapTerritoriesBasedOnStatuses(state);
     } else if (method === "dblClick" && unitID !== clickData.payload.unitID) {


### PR DESCRIPTION
Fixes Bug L#13 and L#14 from Bug Tracker

- Confirm highlight is removed on subsequent orders
- Confirm you can move out from a coast

https://docs.google.com/spreadsheets/d/1f7DgbZoxsI3Gg3_nmEKqB0CF0aECM-jUh4YJx-Oa2zA/edit#gid=1552316984

#### Issue
> Clicking the same unit does not remove the highlight. This means you can click a unit to move, double click it to initiate a support move or hold, and while the move arrow is removed, the highlight stays.

#### Issue
> When a Fleet is in a Coastal Area. The Unit cannot move away from the coast

#### Before

https://drive.google.com/file/d/1x2HXlLSZX5hPlViiVHkPbjqHe7cmWF4u/view?usp=sharing


#### After

https://drive.google.com/file/d/1N8FJVCxEGJ2J7TGRFl3Kh1RjduIleNbl/view?usp=sharing



#### Before



![Screen Shot 2022-05-27 at 2 40 44 PM](https://user-images.githubusercontent.com/1848053/170792596-bf3fc86b-3b5f-484e-9017-8af61b6b4989.png)


#### After



![Screen Shot 2022-05-27 at 4 39 47 PM](https://user-images.githubusercontent.com/1848053/170800518-33cf5ea4-b75f-41be-b1b1-8afe8ce80e49.png)



