### PR TITLE
this fixes most of the UAT bugs

### DIFF
--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -212,6 +212,10 @@ const gameApiSlice = createSlice({
       .addCase(fetchGameData.pending, (state) => {
         state.apiStatus = "loading";
         state.transition = true;
+        state.ordersMeta = {};
+        if (state.overview.phase !== "Builds") {
+          state.mustDestroyUnitsBuildPhase = false;
+        }
       })
       .addCase(fetchGameData.fulfilled, fetchGameDataFulfilled)
       .addCase(fetchGameData.rejected, (state, action) => {


### PR DESCRIPTION
This PR resets ordersMeta and mustDestroyUnit in state when pulling new data.

Test Plan: 
Start game, enter builds phase for destroy and build, make sure all UI is correct, make sure the player that destroys a unit can move after game proceeds to diplomacy