### PR TITLE
addressed caught bugs

### DIFF
--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -212,7 +212,6 @@ const gameApiSlice = createSlice({
       .addCase(fetchGameData.pending, (state) => {
         state.apiStatus = "loading";
         state.transition = true;
-        state.ordersMeta = {};
         if (state.overview.phase !== "Builds") {
           state.mustDestroyUnitsBuildPhase = false;
         }

--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -26,11 +26,6 @@ export default function getUnits(
     const territoryHasMultipleUnits = Object.values(units).filter(
       (u) => u.terrID === unit.terrID,
     );
-    const occupiedTerritory = territoryStatus?.occupiedFromTerrID
-      ? territoryStatuses.find(
-          (t) => territoryStatus?.occupiedFromTerrID === t.id,
-        )
-      : undefined;
 
     if (territory) {
       const mappedTerritory = TerritoryMap[territory.name];
@@ -43,7 +38,6 @@ export default function getUnits(
           if (
             (territoryStatus?.occupiedFromTerrID &&
               unit.id !== territoryStatus.unitID &&
-              occupiedTerritory?.ownerCountryID !== unit.countryID &&
               territoryHasMultipleUnits.length > 1 &&
               phase === "Retreats") ||
             (phase === "Retreats" && territoryHasMultipleUnits.length === 1) ||

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -17,7 +17,6 @@ import updateOrdersMeta from "../../../updateOrdersMeta";
 
 /* eslint-disable no-param-reassign */
 export default function fetchGameDataFulfilled(state: GameState, action): void {
-  state.transition = false;
   state.apiStatus = "succeeded";
   state.data = action.payload;
   const {
@@ -97,4 +96,5 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
   if (!numUnsavedOrders) {
     updateOrdersMeta(state, getOrdersMeta(data, board, phase));
   }
+  state.transition = false;
 }

--- a/beta-src/src/utils/state/updateOrdersMeta.ts
+++ b/beta-src/src/utils/state/updateOrdersMeta.ts
@@ -1,9 +1,14 @@
+import { current } from "@reduxjs/toolkit";
 import { EditOrderMeta } from "../../state/interfaces/SavedOrders";
 import drawOrders from "../map/drawOrders";
 import writeNotifications from "../ui/writeNotifications";
 
 /* eslint-disable no-param-reassign */
 export default function updateOrdersMeta(state, updates: EditOrderMeta): void {
+  if (state.transition) {
+    state.ordersMeta = {};
+  }
+
   Object.entries(updates).forEach(([orderID, update]) => {
     state.ordersMeta[orderID] = {
       ...state.ordersMeta[orderID],


### PR DESCRIPTION
This PR addresses bug that appeared with original fix (in some instances it would error because it was undefined).  This also addresses unnecessary unit hiding condition that effected game. Game now only clears ordersMeta in updateOrdersMeta if game is transitioning; transition boolean change happens after update orders meta now in fulfilled. 